### PR TITLE
Switch to Node 8 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:9-stretch
+FROM docker.io/node:8-stretch
 
 # enable non-free repos, needed for seq-gen
 RUN sed -i 's|deb http://deb.debian.org/debian stretch main|deb http://http.us.debian.org/debian stretch main non-free|' /etc/apt/sources.list


### PR DESCRIPTION
I'd rather start off on an LTS release than on a short-lifetime release.

Plus, there's nothing currently in the project that needs Node 9, and I can't think of anything that it added that we'd want badly.

And if there is something, it's a single character change to get it back.

😃 