### PR TITLE
Automatically push new Docker tags from each branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,21 +47,24 @@ jobs:
     # deploy the docker images to Docker Hub
     - stage: deploy
       env: [TASK=deploy]
-      script: skip
-      after_success:
+      script:
         - image_id="$(docker images -q "$LOCAL_NAME")"
         - |
-          if [[ $TRAVIS_TAG == latest ]]; then
-            docker tag "$image_id" "$DEST_NAME:latest"
-          else if [[ $TRAVIS_BRANCH == master ]]; then
-            docker tag "$image_id" "$DEST_NAME:HEAD"
+          if [[ $TRAVIS_BRANCH == master ]]; then
+            docker_tag="$DEST_NAME:HEAD"
           else if [[ $TRAVIS_TAG ]]; then
-            docker tag "$image_id" "$DEST_NAME:$TRAVIS_TAG"
+            docker_tag="$DEST_NAME:$TRAVIS_TAG"
           else if [[ $TRAVIS_BRANCH ]]; then
-            docker tag "$image_id" "$DEST_NAME:$TRAVIS_BRANCH"
+            docker_tag="$DEST_NAME:$TRAVIS_BRANCH"
           fi
         - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        - docker push hybsearch/hybsearch
+        - docker tag "$image_id" "$docker_tag"
+        - docker push "$docker_tag"
+        - |
+          if [[ $TRAVIS_TAG ]]; then
+            docker tag "$image_id" "$DEST_NAME:latest"
+            docker push "$DEST_NAME:latest"
+          fi
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ addons:
   apt: {packages: [docker-ce]}
 
 env:
-  - LOCAL_NAME=hybsearch
-  - DEST_NAME=docker.io/hybsearch/hybsearch
-  - GIT_TAG="$TRAVIS_TAG"
-  - GIT_BRANCH="$TRAVIS_BRANCH"
-  - GIT_SHA="$TRAVIS_COMMIT"
+  global:
+    - LOCAL_NAME=hybsearch
+    - DEST_NAME=docker.io/hybsearch/hybsearch
+    - GIT_TAG="$TRAVIS_TAG"
+    - GIT_BRANCH="$TRAVIS_BRANCH"
+    - GIT_SHA="$TRAVIS_COMMIT"
 
 before_script:
   - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ stages:
 jobs:
   include:
     # "prepare" just builds and caches the Docker image for us
-    - stage: prepare
-      env: [TASK=prepare]
-      script: skip
+    # - stage: prepare
+    #   env: [TASK=prepare]
+    #   script: skip
 
     # check that the whole pipeline runs at all
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,3 +62,7 @@ jobs:
           fi
         - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         - docker push hybsearch/hybsearch
+
+cache:
+  directories:
+   - ~/docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,51 @@ services:
 addons:
   apt: {packages: [docker-ce]}
 
-before_install:
-  - docker build -t hybsearch .
+env:
+  - LOCAL_NAME=hybsearch
+  - DEST_NAME=docker.io/hybsearch/hybsearch
+  - GIT_TAG="$TRAVIS_TAG"
+  - GIT_BRANCH="$TRAVIS_BRANCH"
+  - GIT_SHA="$TRAVIS_COMMIT"
 
-matrix:
+before_script:
+  - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
+  - docker build --rm=false -t "$LOCAL_NAME" .
+  - mkdir -p ~/docker; docker save "$LOCAL_NAME" > ~/docker/image.tar
+
+stages:
+  - prepare
+  - test
+  - deploy
+
+jobs:
   include:
+    # "prepare" just builds and caches the Docker image for us
+    - stage: prepare
+      script: skip
+
     # check that the whole pipeline runs at all
-    - script: docker run -i --entrypoint /hybsearch/scripts/worker-runner.js hybsearch - < data/emydura-short.gb
+    - stage: test
+      script: docker run -i --entrypoint /hybsearch/scripts/worker-runner.js "$LOCAL_NAME" - < data/emydura-short.gb
 
     # test ent.js against all our sample files
-    - script: docker run --entrypoint /hybsearch/scripts/test-ent.sh hybsearch
+    - stage: test
+      script: docker run --entrypoint /hybsearch/scripts/test-ent.sh "$LOCAL_NAME"
+
+    # deploy the docker images to Docker Hub
+    - stage: deploy
+      script: skip
+      after_success:
+        - image_id="$(docker images -q "$LOCAL_NAME")"
+        - |
+          if [[ $TRAVIS_TAG == latest ]]; then
+            docker tag "$image_id" "$DEST_NAME:latest"
+          else if [[ $TRAVIS_BRANCH == master ]]; then
+            docker tag "$image_id" "$DEST_NAME:HEAD"
+          else if [[ $TRAVIS_TAG ]]; then
+            docker tag "$image_id" "$DEST_NAME:$TRAVIS_TAG"
+          else if [[ $TRAVIS_BRANCH ]]; then
+            docker tag "$image_id" "$DEST_NAME:$TRAVIS_BRANCH"
+          fi
+        - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+        - docker push hybsearch/hybsearch

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       script:
         - image_id="$(docker images -q "$LOCAL_NAME")"
         - |
-          if [[ $TRAVIS_BRANCH == master ]]; then
+          if [[ $TRAVIS_BRANCH = master ]]; then
             docker_tag="$DEST_NAME:HEAD"
           else if [[ $TRAVIS_TAG ]]; then
             docker_tag="$DEST_NAME:$TRAVIS_TAG"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,18 +31,22 @@ jobs:
   include:
     # "prepare" just builds and caches the Docker image for us
     - stage: prepare
+      env: [TASK=prepare]
       script: skip
 
     # check that the whole pipeline runs at all
     - stage: test
+      env: [TASK=worker-runner]
       script: docker run -i --entrypoint /hybsearch/scripts/worker-runner.js "$LOCAL_NAME" - < data/emydura-short.gb
 
     # test ent.js against all our sample files
     - stage: test
+      env: [TASK=test-ent]
       script: docker run --entrypoint /hybsearch/scripts/test-ent.sh "$LOCAL_NAME"
 
     # deploy the docker images to Docker Hub
     - stage: deploy
+      env: [TASK=deploy]
       script: skip
       after_success:
         - image_id="$(docker images -q "$LOCAL_NAME")"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ jobs:
         - |
           if [[ $TRAVIS_BRANCH = master ]]; then
             docker_tag="$DEST_NAME:HEAD"
-          else if [[ $TRAVIS_TAG ]]; then
+          elif [[ $TRAVIS_TAG ]]; then
             docker_tag="$DEST_NAME:$TRAVIS_TAG"
-          else if [[ $TRAVIS_BRANCH ]]; then
+          elif [[ $TRAVIS_BRANCH ]]; then
             docker_tag="$DEST_NAME:$TRAVIS_BRANCH"
           fi
         - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ env:
     - GIT_SHA="$TRAVIS_COMMIT"
 
 before_script:
-  - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
+  # - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
   - docker build --rm=false -t "$LOCAL_NAME" .
-  - mkdir -p ~/docker; docker save "$LOCAL_NAME" > ~/docker/image.tar
+  # - mkdir -p ~/docker; docker save "$LOCAL_NAME" > ~/docker/image.tar
 
 stages:
-  - prepare
+  # - prepare
   - test
   - deploy
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Any changes you make to the JS can be run by simply pressing <kbd>⌘R</kbd>. Th
 ### For the Docker container / data pipeline
 Whenever you change the data pipeline, you will need to rebuild the Docker image.
 
-We recommend using a local Docker tag to test with; anywhere you write `hybsearch/hybsearch`, you should just write `hybsearch` instead.
+We recommend using a local Docker tag to test with; anywhere you would write `hybsearch/hybsearch`, you should just write `hybsearch` instead.
 
 To rebuild the container:
 


### PR DESCRIPTION
Closes #16

Now, if you do `docker run -p 8080:8080 -t hybsearch/hybsearch`, you will get the "latest" tag that we've made (tags will show up in the Releases page: https://github.com/hybsearch/hybsearch/releases). This is the "stable" release of our pipeline.

> For all of these tags, when you want to update the image from the internet, you'll need to do this:
> ```
> docker pull hybsearch/hybsearch:$tag
> ```

We also have a tag for each branch, named after the branch (so, this branch is `hybsearch/hybsearch:auto-build-travis`); a tag for each git tag, named after the tag; and a tag named HEAD, which just tracks the tip of the `master` branch.