### PR TITLE
Only disconnect the child if the child is connected

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -40,7 +40,8 @@ wss.on('connection', ws => {
 	ws.on('close', () => {
 		console.log('connection was closed')
 
-		child.disconnect()
+		if(child.connected)
+			child.disconnect()
 	})
 
 	child.on('message', communique => {
@@ -54,7 +55,8 @@ wss.on('connection', ws => {
 
 		// detach ourselves if the pipeline has finished
 		if (cmd === 'exit' || cmd === 'error') {
-			child.disconnect()
+			if(child.connected)
+				child.disconnect()
 		}
 	})
 })

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -40,8 +40,9 @@ wss.on('connection', ws => {
 	ws.on('close', () => {
 		console.log('connection was closed')
 
-		if(child.connected)
+		if (child.connected) {
 			child.disconnect()
+		}
 	})
 
 	child.on('message', communique => {
@@ -55,8 +56,9 @@ wss.on('connection', ws => {
 
 		// detach ourselves if the pipeline has finished
 		if (cmd === 'exit' || cmd === 'error') {
-			if(child.connected)
+			if (child.connected) {
 				child.disconnect()
+			}
 		}
 	})
 })


### PR DESCRIPTION
This prevents a server crash, but might result in one section of code never being called.  Not sure.  Best to have it in both places, in my opinion.