### PR TITLE
Remove global shared mutable state from ent.js

### DIFF
--- a/lib/ent.js
+++ b/lib/ent.js
@@ -92,10 +92,8 @@ function nmSearch(node) {
 	return { species: [node], nm: nmInstances }
 }
 
-var gnmlist = []
-
 module.exports.strictSearch = strictSearch
-function strictSearch(node, nmInstances = []) {
+function strictSearch(node, nmInstances = [], globalNmList = []) {
 	// Remove individuals after being flagged for inner nm, to prevent
 	// unnecessary repeated nm findings
 	if (node.name && !node.ident) {
@@ -112,10 +110,10 @@ function strictSearch(node, nmInstances = []) {
 		let forRemoval = []
 		for (let speciesSet of combinations) {
 			// if species is in speciesList: continue
-			let resultsA = strictSearch(speciesSet[1], nmInstances)
+			let resultsA = strictSearch(speciesSet[1], nmInstances, globalNmList)
 			let speciesListA = resultsA.species
 
-			let resultsB = strictSearch(speciesSet[0], nmInstances)
+			let resultsB = strictSearch(speciesSet[0], nmInstances, globalNmList)
 			let speciesListB = resultsB.species
 
 			// debug('speciesListA:', speciesListA, 'speciesListB', speciesListB)
@@ -144,8 +142,8 @@ function strictSearch(node, nmInstances = []) {
 
 								nmInstances.push([species1, species3])
 
-								if (!gnmlist.some(pairCheck)) {
-									gnmlist.push([species1, species3])
+								if (!globalNmList.some(pairCheck)) {
+									globalNmList.push([species1, species3])
 								}
 
 								forRemoval.push(species3.ident)
@@ -177,8 +175,9 @@ function strictSearch(node, nmInstances = []) {
 
 module.exports.formatData = formatData
 function formatData(results) {
+	const {nm: nmlist} = results
 	// prettier-ignore
-	return gnmlist
+	return nmlist
 		.map(pair => pair.map(label).join(' / '))
 		.join('\n')
 }


### PR DESCRIPTION
Realized that Ent was sharing a global array… I've now removed that.

And, because I added tests for ent earlier this week, I'm fairly sure that this doesn't break anything!