### PR TITLE
Ent in pipeline

### DIFF
--- a/electron/graph.js
+++ b/electron/graph.js
@@ -5,10 +5,26 @@ const d3 = require('d3')
 d3.phylogram = require('../vendor/d3.phylogram')
 
 const ent = require('../lib/ent')
-
 module.exports.load = load
-function load(newick) {
-	const newickNodes = []
+module.exports.setEntResults = setEntResults
+
+let nmResults
+let newick
+let newickNodes
+
+function setEntResults(results){
+	nmResults = results
+	let formattedReslults = ent.formatData(nmResults)
+	let resultsEl = document.querySelector('#nonmonophyly-results')
+	resultsEl.innerHTML = `<pre>${formattedReslults}</pre>`
+	document.querySelector('#nm-container').hidden = false
+
+	render(newick, newickNodes, nmResults)
+}
+
+function load(newickData) {
+	newick = newickData
+	newickNodes = []
 	function buildNewickNodes(node) {
 		newickNodes.push(node)
 		if (node.branchset) {
@@ -17,14 +33,6 @@ function load(newick) {
 	}
 
 	buildNewickNodes(newick)
-	let nmResults = ent.strictSearch(newick)
-	let results = ent.formatData(nmResults)
-	let resultsEl = document.querySelector('#nonmonophyly-results')
-	resultsEl.innerHTML = `<pre>${results}</pre>`
-	document.querySelector('#nm-container').hidden = false
-
-	console.log('Got nodes:', newickNodes)
-	console.log('nonmonophyly:', nmResults)
 
 	render(newick, newickNodes, nmResults)
 
@@ -36,6 +44,9 @@ function load(newick) {
 }
 
 function render(newickData, newickNodes, nmResults) {
+	// nmResults is optional. If not passed, tree will be drawn with no marked nodes.
+	// This is to allow the tree to be drawn while the ent search goes on. 
+
 	// Scale the generated tree based on largest branch length
 	const smallest = getSmallestLength(newickNodes)
 	const largest = getLargestLength(newickNodes)
@@ -55,7 +66,7 @@ function render(newickData, newickNodes, nmResults) {
 			let name = node.name.replace(/_/g, ' ')
 			return `${name} [${node.ident}] (${node.length})`
 		},
-		nonmonophyly: nmResults.nm.map(pair => pair.map(node => node.ident)),
+		nonmonophyly: nmResults ? nmResults.nm.map(pair => pair.map(node => node.ident)) : null,
 		onNodeClicked: onNodeClicked,
 	})
 }

--- a/electron/graph.js
+++ b/electron/graph.js
@@ -14,11 +14,17 @@ let newickNodes
 
 function setEntResults(results){
 	nmResults = results
+	console.log("Got ent!",results)
+	let non = (nmResults !== undefined) ? nmResults.nm.map(pair => pair.map(node => node.ident)) : null
+	console.log(non)
 	let formattedReslults = ent.formatData(nmResults)
 	let resultsEl = document.querySelector('#nonmonophyly-results')
 	resultsEl.innerHTML = `<pre>${formattedReslults}</pre>`
 	document.querySelector('#nm-container').hidden = false
 
+	// Re-render with the nmResults, assuming newick and newickNodes have already been processed
+	let el = document.querySelector('#phylogram')
+	if (el) el.innerHTML = ''
 	render(newick, newickNodes, nmResults)
 }
 
@@ -66,7 +72,7 @@ function render(newickData, newickNodes, nmResults) {
 			let name = node.name.replace(/_/g, ' ')
 			return `${name} [${node.ident}] (${node.length})`
 		},
-		nonmonophyly: nmResults ? nmResults.nm.map(pair => pair.map(node => node.ident)) : null,
+		nonmonophyly: (nmResults !== undefined) ? nmResults.nm.map(pair => pair.map(node => node.ident)) : null,
 		onNodeClicked: onNodeClicked,
 	})
 }

--- a/electron/graph.js
+++ b/electron/graph.js
@@ -70,6 +70,7 @@ function render(newickData, newickNodes, nmResults) {
 		height: calcHeight,
 		formatLeafNodeLabel: node => {
 			let name = node.name.replace(/_/g, ' ')
+			console.log(node)
 			return `${name} [${node.ident}] (${node.length})`
 		},
 		nonmonophyly: (nmResults !== undefined) ? nmResults.nm.map(pair => pair.map(node => node.ident)) : null,

--- a/electron/index.html
+++ b/electron/index.html
@@ -49,6 +49,14 @@
 					<div class="icon"></div>
 					<div class="label">Render Tree</div>
 				</div>
+				<div class="checkmark" data-loader-name="newick">
+					<div class="icon"></div>
+					<div class="label">Parsing Newick</div>
+				</div>
+				<div class="checkmark" data-loader-name="ent">
+					<div class="icon"></div>
+					<div class="label">Running Ent</div>
+				</div>
 			</wrapper>
 		</section>
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -12,6 +12,7 @@ const fastaToNexus = require('../bin/fasta-to-nexus')
 const mrBayes = require('../bin/mrbayes')
 const consensusTreeToNewick = require('../bin/consensus-newick')
 const { parse: parseNewick } = require('../vendor/newick')
+const ent = require('../lib/ent')
 
 process.on('disconnect', () => {
 	console.error('disconnected')
@@ -26,7 +27,7 @@ const send = (cmd, msg) => sendFunc([cmd, msg])
 const begin = msg => send('begin', msg)
 const complete = msg => send('complete', msg)
 const error = e => send('error', serializeError(e))
-const returnData = (phase, data) => send('data', [data])
+const returnData = (phase, data) => send('data', {phase:phase,data:data})
 const exit = () => send('exit')
 
 async function main([command, filepath, data]) {
@@ -55,20 +56,20 @@ async function main([command, filepath, data]) {
 		complete('condense')
 
 		begin('newick')
-		let jsonNewickTree = parseNewick(data)
+		let jsonNewickTree = parseNewick(newickTree)
 		returnData('newick', jsonNewickTree)
-		end('newick')
+		complete('newick')
 
 		begin('ent')
 		let nmResults = ent.strictSearch(jsonNewickTree)
-		returnData('ent', nmResults)
-		end('ent')
+		returnData('ent', {})
+		complete('ent')
 
-		begin('hamdis')
-		end('hamdis')
+		// begin('hamdis')
+		// end('hamdis')
 
-		begin('seqgen')
-		end('seqgen')
+		// begin('seqgen')
+		// end('seqgen')
 
 	} catch (err) {
 		error(err)

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -62,7 +62,12 @@ async function main([command, filepath, data]) {
 
 		begin('ent')
 		let nmResults = ent.strictSearch(jsonNewickTree)
-		returnData('ent', {})
+		let nonCircularResults = JSON.parse(JSON.stringify(nmResults,function(key,val){
+			if(key == 'parent' || key == 'nm_inner' || key == 'nm_outer')
+				return undefined
+			return val
+		}))
+		returnData('ent', nonCircularResults)
 		complete('ent')
 
 		// begin('hamdis')

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -30,6 +30,14 @@ const error = e => send('error', serializeError(e))
 const returnData = (phase, data) => send('data', {phase:phase,data:data})
 const exit = () => send('exit')
 
+function removeCircularLinks(obj){
+	return JSON.parse(JSON.stringify(obj,function(key,val){
+		if(key == 'parent' || key == 'nm_inner' || key == 'nm_outer')
+			return undefined
+		return val
+	}))
+}
+
 async function main([command, filepath, data]) {
 	try {
 		begin('process')
@@ -61,13 +69,11 @@ async function main([command, filepath, data]) {
 		complete('newick')
 
 		begin('ent')
-		let nmResults = ent.strictSearch(jsonNewickTree)
-		let nonCircularResults = JSON.parse(JSON.stringify(nmResults,function(key,val){
-			if(key == 'parent' || key == 'nm_inner' || key == 'nm_outer')
-				return undefined
-			return val
-		}))
-		returnData('ent', nonCircularResults)
+		let nmResults = removeCircularLinks(ent.strictSearch(jsonNewickTree))
+		// Have to return newick again because apparently `strictSearch`
+		// actually modifies the data
+		returnData('newick', removeCircularLinks(jsonNewickTree))
+		returnData('ent', nmResults)
 		complete('ent')
 
 		// begin('hamdis')

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -11,6 +11,7 @@ const clustal = require('../bin/clustal-o')
 const fastaToNexus = require('../bin/fasta-to-nexus')
 const mrBayes = require('../bin/mrbayes')
 const consensusTreeToNewick = require('../bin/consensus-newick')
+const { parse: parseNewick } = require('../vendor/newick')
 
 process.on('disconnect', () => {
 	console.error('disconnected')
@@ -25,7 +26,7 @@ const send = (cmd, msg) => sendFunc([cmd, msg])
 const begin = msg => send('begin', msg)
 const complete = msg => send('complete', msg)
 const error = e => send('error', serializeError(e))
-const returnData = data => send('finish', data)
+const returnData = (phase, data) => send('data', [data])
 const exit = () => send('exit')
 
 async function main([command, filepath, data]) {
@@ -53,7 +54,22 @@ async function main([command, filepath, data]) {
 		let newickTree = consensusTreeToNewick(tree)
 		complete('condense')
 
-		returnData(newickTree)
+		begin('newick')
+		let jsonNewickTree = parseNewick(data)
+		returnData('newick', jsonNewickTree)
+		end('newick')
+
+		begin('ent')
+		let nmResults = ent.strictSearch(jsonNewickTree)
+		returnData('ent', nmResults)
+		end('ent')
+
+		begin('hamdis')
+		end('hamdis')
+
+		begin('seqgen')
+		end('seqgen')
+
 	} catch (err) {
 		error(err)
 		console.error(err)


### PR DESCRIPTION
I've completed adding the Ent search and parsing the newick tree as two new steps in the pipeline. I've also finished the `returnData` method so that the server can send data back to the client at multiple points and the client handles that. 

The app will now draw the tree immediately with no monophyly data yet. Once the ent is complete, it will redraw the graph with colors. 

### Issues

I've opened this PR in case someone else is blocked on this. I've taken some shortcuts that I'd like to find better solutions for. Specifically I've realized that the `ent.strictSearch` function actually modifies the given newick tree, adding in data that is needed to correct mark the red nodes. My solution for now is resending the modified newick tree once the ent search is complete. 
