### PR TITLE
Clicking a node highlights its nonmonophylic pair

### DIFF
--- a/electron/graph.js
+++ b/electron/graph.js
@@ -12,6 +12,8 @@ let nmResults
 let newick
 let newickNodes
 
+let nodesMuted = false;
+
 function setEntResults(results){
 	nmResults = results
 	console.log("Got ent!",results)
@@ -122,19 +124,61 @@ function findOutliers(objs, whitelist, found = []) {
 	return found
 }
 
+function ToggleMuteLeaves(doMute){
+	var nodes = document.querySelectorAll(".node.leaf")
+	nodesMuted = doMute
+	for(var i=0;i<nodes.length;i++){
+		var node = nodes[i];
+		var isMuted = node.className.baseVal.indexOf("muted") != -1;
+		if(doMute && !isMuted){
+			node.className.baseVal += " muted"
+		}
+		if(!doMute && isMuted){
+			node.className.baseVal = node.className.baseVal.replace("muted","")
+		}
+		
+	}
+}
+
 function onNodeClicked(data) {
-	console.log('Clicked on node point with data:', data)
+	if(data.name == "" || nmResults == undefined)
+		return; // We don't care about anything that's not a leaf node
+	// Find the other individual that is nonmonophyletic with this one
+	var nonmono_pair;
+	for(var i=0;i<nmResults.nm.length;i++){
+		var pair = nmResults.nm[i];
+		if(pair[0].ident == data.ident){
+			nonmono_pair = pair[1];
+			break;
+		}
+		if(pair[1].ident == data.ident){
+			nonmono_pair = pair[0];
+			break;
+		}
+	}
+	// Now let's toggle the non-mono pair green if one was found
 
-	let outliers = findOutliers(data.branchset, getWhitelist())
-	console.log('Outliers found:', outliers)
+	if(nonmono_pair){
+		// If it's already muted, toggle all off 
+		var nodeSVG = document.querySelector("[data-ident='"+data.ident+"']")
+		var pairSVG = document.querySelector("[data-ident='"+nonmono_pair.ident+"']")
+		if(nodesMuted){
+			ToggleMuteLeaves(false)
+		} else {
+			// First we set all nodes to muted
+			ToggleMuteLeaves(true);
+			// Except for the one and its pair 
+			nodeSVG.className.baseVal = nodeSVG.className.baseVal.replace("muted","")
+			pairSVG.className.baseVal = pairSVG.className.baseVal.replace("muted","")
 
-	outliers.forEach(outlier =>
-		document.getElementById(outlier).setAttribute('fill', 'green')
-	)
+			alert(data.name + data.ident + " is nonmono with " + nonmono_pair.name + nonmono_pair.ident)
+		}
+	} else {
+		ToggleMuteLeaves(false);
+		alert("This node is not monophyletic!")
+	}
+	
 
-	alert(
-		'Node analysis complete! Non-dominant species for the specified subtree are marked green. For a comprehensive list, please view the browser console logs.'
-	)
 }
 
 function getWhitelist() {

--- a/electron/graph.js
+++ b/electron/graph.js
@@ -12,8 +12,6 @@ let nmResults
 let newick
 let newickNodes
 
-let nodesMuted = false;
-
 function setEntResults(results){
 	nmResults = results
 	console.log("Got ent!",results)
@@ -124,19 +122,14 @@ function findOutliers(objs, whitelist, found = []) {
 	return found
 }
 
-function ToggleMuteLeaves(doMute){
-	var nodes = document.querySelectorAll(".node.leaf")
-	nodesMuted = doMute
-	for(var i=0;i<nodes.length;i++){
-		var node = nodes[i];
-		var isMuted = node.className.baseVal.indexOf("muted") != -1;
-		if(doMute && !isMuted){
-			node.className.baseVal += " muted"
+function toggleMuteLeaves({doMute}){
+	const nodes = document.querySelectorAll(".node.leaf")
+	for (let node of nodes) {
+		if (doMute) {
+			node.classList.add('muted')
+		} else {
+			node.classList.remove('muted')
 		}
-		if(!doMute && isMuted){
-			node.className.baseVal = node.className.baseVal.replace("muted","")
-		}
-		
 	}
 }
 
@@ -144,37 +137,36 @@ function onNodeClicked(data) {
 	if(data.name == "" || nmResults == undefined)
 		return; // We don't care about anything that's not a leaf node
 	// Find the other individual that is nonmonophyletic with this one
-	var nonmono_pair;
-	for(var i=0;i<nmResults.nm.length;i++){
-		var pair = nmResults.nm[i];
+	var nonMonoPair;
+	for(let pair of nmResults.nm) {
 		if(pair[0].ident == data.ident){
-			nonmono_pair = pair[1];
+			nonMonoPair = pair[1];
 			break;
 		}
 		if(pair[1].ident == data.ident){
-			nonmono_pair = pair[0];
+			nonMonoPair = pair[0];
 			break;
 		}
 	}
 	// Now let's toggle the non-mono pair green if one was found
 
-	if(nonmono_pair){
+	if(nonMonoPair){
 		// If it's already muted, toggle all off 
-		var nodeSVG = document.querySelector("[data-ident='"+data.ident+"']")
-		var pairSVG = document.querySelector("[data-ident='"+nonmono_pair.ident+"']")
-		if(nodesMuted){
-			ToggleMuteLeaves(false)
+		var nodeSVG = document.querySelector(`[data-ident='${data.ident}']`)
+		var pairSVG = document.querySelector(`[data-ident='${nonMonoPair.ident}']`)
+		if(document.querySelector('.node.leaf.muted')){
+			toggleMuteLeaves({doMute:false})
 		} else {
 			// First we set all nodes to muted
-			ToggleMuteLeaves(true);
+			toggleMuteLeaves({doMute:true});
 			// Except for the one and its pair 
-			nodeSVG.className.baseVal = nodeSVG.className.baseVal.replace("muted","")
-			pairSVG.className.baseVal = pairSVG.className.baseVal.replace("muted","")
+			nodeSVG.classList.remove('muted')
+			pairSVG.classList.remove('muted')
 
-			alert(data.name + data.ident + " is nonmono with " + nonmono_pair.name + nonmono_pair.ident)
+			alert(data.name + data.ident + " is nonmono with " + nonMonoPair.name + nonMonoPair.ident)
 		}
 	} else {
-		ToggleMuteLeaves(false);
+		toggleMuteLeaves({doMute:false});
 		alert("This node is not monophyletic!")
 	}
 	

--- a/electron/index.css
+++ b/electron/index.css
@@ -226,12 +226,12 @@ section button {
 	fill: var(--blue);
 }
 
-.clickable-node {
-	fill: var(--black);
-}
-
 .nonmonophyletic .leaf-dot {
 	fill: var(--red);
+}
+
+.muted .leaf-dot {
+	opacity: 0.2;
 }
 
 #reload-container {

--- a/vendor/d3.phylogram.js
+++ b/vendor/d3.phylogram.js
@@ -167,6 +167,8 @@ phylogram.styleTreeNodes = (vis, onClickFunc) => {
 		.append('svg:circle')
 		.attr('r', 4)
 		.classed('leaf-dot', true)
+		.classed('clickable-node', true)
+		.on('click', onClickFunc)
 		// .attr('data-ident', node => node.ident)
 		.attr('id', d => `${d.name}_${d.length}`)
 
@@ -174,8 +176,9 @@ phylogram.styleTreeNodes = (vis, onClickFunc) => {
 		.selectAll('g.root.node')
 		.append('svg:circle')
 		.attr('r', 4)
-		.classed('clickable-node', true)
-		.on('click', onClickFunc)
+		//.classed('clickable-node', true)
+		//.on('click', onClickFunc)
+
 }
 
 function visitPreOrder(root, callback) {


### PR DESCRIPTION
This fixes #42 by refactoring what clicking does. The old code was throwing an error because it was attempting to get input from an html input field that no longer exist.

The new behavior accepts clicks on any leaf node, and will pop up an alert telling you its pair. It will also set all other nodes except for the pair to opacity 0.2 so that it is visually easy to find the pair. Clicking again will reset everything to opacity 1 (clicking on a blue dot will also set opacity to 1). 

I would personally prefer to chuck the alert and just have it toggle the opacity, but I'm keeping it for now in case the biologists' use case is more about just getting the number than seeing it in the tree. 