### PR TITLE
Point fasta-to-nexus to /usr/local/bin/seqmagick

### DIFF
--- a/bin/fasta-to-nexus.js
+++ b/bin/fasta-to-nexus.js
@@ -12,7 +12,7 @@ function seqmagick(data) {
 
 	// prettier-ignore
 	let args = [
-		'/usr/bin/seqmagick',
+		'/usr/local/bin/seqmagick',
 		'convert',
 		'--input-format', 'fasta',
 		'--output-format', 'nexus',


### PR DESCRIPTION
Not necessarily the best of the options, but this does actually work pretty well.

I'd prefer us to use something like `which` to find it, but this solves the immediate problem on `master`.

Closes #56.