### PR TITLE
Centralize the .gitignore and .dockerignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,1 @@
-.git/
-.vscode/
-electron/
-node_modules/
-data/*
-*.tar.gz
-*.tar
-.eslintcache
+.ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,1 @@
-.DS_Store
-node_modules/.bin
-node_modules/.staging
-*.pyc
-npm-debug.log
-.vscode/
-.idea/
-dist/
-node_modules/
-.eslintcache
+.ignore

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,13 @@
+*.log
+*.pyc
+*.tar
+*.tar.gz
+.DS_Store
+.eslintcache
+.git/
+.idea/
+.vscode/
+data/*
+dist/
+electron/
+node_modules/


### PR DESCRIPTION
I symlinked them both to the new `.ignore` file.

For our case, they should have the same content, so it makes sense to make them be the same file.