### PR TITLE
Enable building the app on tag pushes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ workflows:
           context: docker-hub
       - deploy-github:
           requires: [test-worker, test-js]
+          filters: *filters
 
   cron_weekly:
     jobs:


### PR DESCRIPTION
we should have been doing this already

this allows circle to build and upload app binaries when we push a new tag