### PR TITLE
Include a docker-compose.yml file

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,14 @@
+---
+version: '3'
+services:
+  hs:
+    image: docker.io/hybsearch/hybsearch:latest
+    restart: unless-stopped
+    ports:
+      - 0.0.0.0:80:8080
+
+  hs-head:
+    image: docker.io/hybsearch/hybsearch:HEAD
+    restart: unless-stopped
+    ports:
+      - 0.0.0.0:81:8080


### PR DESCRIPTION
This is a one-to-one representation of what we run on thing3, and will make my life easier when I want to deploy on thing3.

I suppose you can just build that specific tag locally (`docker.io/hybsearch/hybsearch:HEAD`) as your development and run this locally, too.  (But it'll yell about port permissions, probably, lol)