### PR TITLE
Tweak the Prettier config a bit

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+package.json
+package-lock.json
+*/out/*

--- a/electron/package.json
+++ b/electron/package.json
@@ -12,7 +12,7 @@
     "pack": "electron-builder --dir",
     "test": "PATH=$PATH:../node_modules/.bin; jest",
     "lint": "cd .. && npm run lint",
-    "prettier": "cd .. && npm run prettier",
+    "prettify": "cd .. && npm run prettify",
     "pretty-check": "cd .. && npm run pretty-check",
     "start": "electron ./main.js"
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "start": "cd electron && npm start",
     "test": "jest",
     "lint": "eslint --cache 'server/**/*.js' 'server/**/hyb-*' 'electron/**/*.js'",
-    "pretty-check": "npm run prettier -- --list-different",
-    "prettier": "prettier --write 'server/**/*.js' 'server/**/hyb-*' 'electron/**/*.{js,css}'"
+    "pretty-check": "npm run prettify -- --list-different",
+    "prettify": "prettier --write 'server/**/*.js' 'server/**/hyb-*' 'electron/**/*.{js,css}'"
   },
   "prettier": {
     "overrides": [

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "eslint-plugin-import": "^2.9.0",
     "expect": "^22.4.0",
     "jest": "^22.4.2",
-    "prettier": "1.11.1"
+    "prettier": "^1.11.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,12 +22,6 @@
         "options": {
           "parser": "babylon"
         }
-      },
-      {
-        "files": "{package,package-lock}.json",
-        "options": {
-          "requirePragma": true
-        }
       }
     ],
     "useTabs": true,

--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "./server.js",
     "lint": "cd .. && npm run lint",
-    "prettier": "cd .. && npm run prettier",
+    "prettify": "cd .. && npm run prettify",
     "pretty-check": "cd .. && npm run pretty-check",
     "test": "PATH=$PATH:../node_modules/.bin; jest"
   },


### PR DESCRIPTION
This doesn't actually have any changes to the formatting.

- Uses the `.prettierignore` file to show that we're actually just ignoring these files
- Uses `^` notation when depending on `prettier`, to match all our other deps
- Renames `npm run prettier` to `npm run prettify` to allow future use cases (for instance, `yarn` lets you run any installed binary with `yarn $binary`, which I've found myself doing several times now.)

Split out from #73 