### PR TITLE
Clean up the electron-builder config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@
 .git/
 .idea/
 .vscode/
-dist/
 node_modules/
+
+# the electron compilation folder
+dist/

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hybsearch/electron",
+  "name": "hybsearch-electron",
   "version": "4.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hybsearch/electron",
+  "name": "hybsearch-electron",
   "private": true,
   "version": "4.0.0-beta.3",
   "description": "an electron gui for hybsearch",

--- a/electron/package.json
+++ b/electron/package.json
@@ -19,6 +19,16 @@
   "build": {
     "appId": "edu.stolaf.bio.hybsearch",
     "productName": "HybSearch",
+    "mac": {
+      "target": [{"target": "zip", "arch": "x64"}]
+    },
+    "win": {
+      "target": [{"target": "portable", "arch": "x64"}]
+    },
+    "linux": {
+      "target": [{"target": "tar.gz", "arch": "x64"}],
+      "category": "Education"
+    },
     "files": [
       "lib/",
       "*.css",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "@hybsearch/server",
+	"name": "hybsearch-server",
 	"version": "4.0.0-beta.3",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hybsearch/server",
+  "name": "hybsearch-server",
   "private": true,
   "version": "4.0.0-beta.3",
   "description": "Find nonmonophyly in genetic sequences",


### PR DESCRIPTION
Split out from #73 

- Renames the packages to remove the scope; it was pointless, and a few things wound up creating accidentally nested folders because of the slash
- Added a comment about why we ignore `dist/`
- Reduces the number of generated files, from `dmg(osx)`/`zip(osx)`/`exe(win)`/`snap(linux)`/`appimage(linux)` to just `zip(osx)`/`exe(win)`/`.tar.gz(linux)` – also the .dmg/.appimage weren't even being created right, so this reduces the number of errors logged, as well