### PR TITLE
Cache the pipeline

### DIFF
--- a/electron/index.css
+++ b/electron/index.css
@@ -100,6 +100,10 @@ section.loader.loading wrapper.content {
 	color: var(--navy);
 }
 
+.loader .checkmark.used-cache {
+	color: var(--green);
+}
+
 @keyframes pulse {
 	0% {
 		transform: scale3d(0.9, 0.9, 0.9);

--- a/electron/index.html
+++ b/electron/index.html
@@ -29,31 +29,31 @@
 				<button id="start">Run Hybsearch</button>
 			</wrapper>
 			<wrapper class="loading">
-				<div class="checkmark" data-loader-name="process">
+				<div class="checkmark" data-loader-name="initial-fasta">
 					<div class="icon"></div>
 					<div class="label">Process Input</div>
 				</div>
-				<div class="checkmark" data-loader-name="align">
+				<div class="checkmark" data-loader-name="aligned-fasta">
 					<div class="icon"></div>
 					<div class="label">Align Sequences</div>
 				</div>
-				<div class="checkmark" data-loader-name="convert">
+				<div class="checkmark" data-loader-name="aligned-nexus">
 					<div class="icon"></div>
 					<div class="label">Convert Alignment</div>
 				</div>
-				<div class="checkmark" data-loader-name="generate">
+				<div class="checkmark" data-loader-name="consensus-tree">
 					<div class="icon"></div>
 					<div class="label">Generate Tree</div>
 				</div>
-				<div class="checkmark" data-loader-name="condense">
+				<div class="checkmark" data-loader-name="newick-tree">
 					<div class="icon"></div>
 					<div class="label">Render Tree</div>
 				</div>
-				<div class="checkmark" data-loader-name="newick">
+				<div class="checkmark" data-loader-name="newick-json">
 					<div class="icon"></div>
 					<div class="label">Parsing Newick</div>
 				</div>
-				<div class="checkmark" data-loader-name="ent">
+				<div class="checkmark" data-loader-name="nonmonophyletic-sequences">
 					<div class="icon"></div>
 					<div class="label">Running Ent</div>
 				</div>

--- a/electron/run.js
+++ b/electron/run.js
@@ -77,7 +77,11 @@ function onMessage(packet) {
 		beginLoadingStatus(stage.split(':')[0])
 	} else if (type === 'stage-complete') {
 		const { stage, timeTaken, result, cached } = payload
-		updateLoadingStatus({label: stage.split(':')[0], duration: timeTaken.toFixed(2), usedCache: cached})
+		updateLoadingStatus({
+			label: stage.split(':')[0],
+			duration: timeTaken.toFixed(2),
+			usedCache: cached,
+		})
 		onData(stage, result)
 	} else if (type === 'error') {
 		let { error, timeTaken } = payload
@@ -122,7 +126,7 @@ function attachListeners() {
 	})
 }
 
-function updateLoadingStatus({label, duration, usedCache}) {
+function updateLoadingStatus({ label, duration, usedCache }) {
 	console.info(`finished ${label} in ${duration}ms`)
 	let el = document.querySelector(`.checkmark[data-loader-name='${label}']`)
 	if (!el) {

--- a/electron/run.js
+++ b/electron/run.js
@@ -76,8 +76,8 @@ function onMessage(packet) {
 		const { stage } = payload
 		beginLoadingStatus(stage.split(':')[0])
 	} else if (type === 'stage-complete') {
-		const { stage, timeTaken, result } = payload
-		updateLoadingStatus(stage.split(':')[0], timeTaken.toFixed(2))
+		const { stage, timeTaken, result, cached } = payload
+		updateLoadingStatus({label: stage.split(':')[0], duration: timeTaken.toFixed(2), usedCache: cached})
 		onData(stage, result)
 	} else if (type === 'error') {
 		let { error, timeTaken } = payload
@@ -122,8 +122,8 @@ function attachListeners() {
 	})
 }
 
-function updateLoadingStatus(label, timeTaken) {
-	console.info(`finished ${label} in ${timeTaken}ms`)
+function updateLoadingStatus({label, duration, usedCache}) {
+	console.info(`finished ${label} in ${duration}ms`)
 	let el = document.querySelector(`.checkmark[data-loader-name='${label}']`)
 	if (!el) {
 		console.error(`could not find .checkmark[data-loader-name='${label}']`)
@@ -131,7 +131,8 @@ function updateLoadingStatus(label, timeTaken) {
 	}
 	el.classList.remove('active')
 	el.classList.add('complete')
-	el.dataset.time = timeTaken
+	usedCache && el.classList.add('used-cache')
+	el.dataset.time = duration
 }
 
 function beginLoadingStatus(label) {

--- a/electron/run.js
+++ b/electron/run.js
@@ -57,8 +57,16 @@ function onData(phase, data) {
 			break
 		}
 		case 'prune': {
-			document.querySelector('#omitted-container').hidden = false
-			document.querySelector('#omitted-results').innerHTML = data.formattedNames
+			let container = document.querySelector('#omitted-results')
+
+			let formattedNames = data.map(node => {
+				let ident = node.ident ? ` [${node.ident}]` : ''
+				return `${node.name}${ident} (${node.length})`
+			})
+
+			container.innerHTML = `<pre>${formattedNames.join('\n')}</pre>`
+			container.hidden = false
+
 			break
 		}
 		case 'ent': {

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -4,31 +4,31 @@ const groupBy = require('lodash/groupBy')
 const mapValues = require('lodash/mapValues')
 const toPairs = require('lodash/toPairs')
 const getFiles = require('./lib/get-files')
-const run = require('./run')
+const { attachListeners } = require('./run')
 
-let websocket = new WebSocket(document.querySelector('#server-url').value)
+attachListeners()
+
+global.socket = new WebSocket(document.querySelector('#server-url').value)
 initWebsocket()
 
 function updateWebSocket(newUri) {
 	console.log('new websocket', newUri)
 	document.querySelector('#server-url').value = newUri
 	destroyWebsocket()
-	websocket = new WebSocket(newUri)
+	global.socket = new WebSocket(newUri)
 	initWebsocket()
 }
 
 function initWebsocket() {
-	websocket.addEventListener('open', connectionIsUp)
-	websocket.addEventListener('error', connectionRefused)
+	global.socket.addEventListener('open', connectionIsUp)
+	global.socket.addEventListener('error', connectionRefused)
 }
 
 function destroyWebsocket() {
-	websocket.removeEventListener('open', connectionIsUp)
-	websocket.removeEventListener('error', connectionRefused)
-	websocket.close()
+	global.socket.removeEventListener('open', connectionIsUp)
+	global.socket.removeEventListener('error', connectionRefused)
+	global.socket.close()
 }
-
-document.querySelector('#start').addEventListener('click', () => run(websocket))
 
 document.querySelector('#use-thing3').addEventListener('click', () => {
 	const newUri = document.querySelector('#use-thing3').dataset.url
@@ -89,7 +89,3 @@ for (let [type, options] of toPairs(optgroups)) {
 	options.forEach(opt => group.appendChild(opt))
 	picker.appendChild(group)
 }
-
-document.querySelector('#reload').addEventListener('click', () => {
-	window.location.reload()
-})

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -20,4 +20,6 @@ WORKDIR /hybsearch
 RUN pip install -r requirements.txt
 RUN npm install
 
+ENV DOCKER=1
+
 CMD npm start -- 8080

--- a/server/lib/prune-newick.js
+++ b/server/lib/prune-newick.js
@@ -100,7 +100,11 @@ function pruneOutliers(newick, alignedFasta) {
 		delete newick.length
 	}
 
-	return { prunedNewick: newick, removedData: removedData, standardDeviationOfRemoved: std }
+	return {
+		prunedNewick: newick,
+		removedData: removedData,
+		standardDeviationOfRemoved: std,
+	}
 }
 
 function removeNodes(node, identArray) {

--- a/server/lib/prune-newick.js
+++ b/server/lib/prune-newick.js
@@ -89,19 +89,13 @@ function pruneOutliers(newick, alignedFasta) {
 	// Now remove the nodes
 	let removedData = { total: 0, standardDeviation: std }
 
-	if (toRemoveNodes.length !== 0) {
-		removedData.total = toRemoveNodes.length
-		removedData.formattedNames = '<pre>'
-		for (let node of toRemoveNodes) {
-			let name = node.name
-			if (node.ident) {
-				name += `[${node.ident}]`
-			}
-			removedData.formattedNames +=
-				String(name) + ' (' + String(node.length) + ')'
-			removedData.formattedNames += '\n'
-		}
-		removedData.formattedNames += '</pre>'
+	if (toRemoveNodes.length > 0) {
+		removedData = toRemoveNodes.map(node => ({
+			name: node.name,
+			ident: node.ident,
+			length: node.length,
+		}))
+
 		removeNodes(newick, toRemoveNames)
 		newick = removeRedundant(newick)
 		delete newick.length

--- a/server/lib/prune-newick.js
+++ b/server/lib/prune-newick.js
@@ -87,8 +87,7 @@ function pruneOutliers(newick, alignedFasta) {
 	}
 
 	// Now remove the nodes
-	let removedData = { total: 0, standardDeviation: std }
-
+	let removedData = []
 	if (toRemoveNodes.length > 0) {
 		removedData = toRemoveNodes.map(node => ({
 			name: node.name,
@@ -101,7 +100,7 @@ function pruneOutliers(newick, alignedFasta) {
 		delete newick.length
 	}
 
-	return { prunedNewick: newick, removedData: removedData }
+	return { prunedNewick: newick, removedData: removedData, standardDeviationOfRemoved: std }
 }
 
 function removeNodes(node, identArray) {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -31,6 +31,11 @@
 				"which": "1.3.0"
 			}
 		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -92,6 +97,14 @@
 				"signal-exit": "3.0.2"
 			}
 		},
+		"make-dir": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"requires": {
+				"pify": "3.0.0"
+			}
+		},
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -119,6 +132,11 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -170,6 +188,23 @@
 			"requires": {
 				"temp-dir": "1.0.0",
 				"uuid": "3.2.1"
+			}
+		},
+		"tempy": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
+			"integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
+			"requires": {
+				"temp-dir": "1.0.0",
+				"unique-string": "1.0.0"
+			}
+		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"requires": {
+				"crypto-random-string": "1.0.0"
 			}
 		},
 		"uuid": {

--- a/server/package.json
+++ b/server/package.json
@@ -33,9 +33,11 @@
     "get-stdin": "^6.0.0",
     "lodash": "^4.17.5",
     "loud-rejection": "^1.6.0",
+    "make-dir": "^1.2.0",
     "minimist": "^1.2.0",
     "serialize-error": "^2.1.0",
     "tempfile": "^2.0.0",
+    "tempy": "^0.2.1",
     "wordwrap": "^1.0.0",
     "ws": "^4.1.0"
   }

--- a/server/pipeline/cache.js
+++ b/server/pipeline/cache.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const crypto = require('crypto')
+const tempy = require('tempy')
+const fs = require('fs')
+const path = require('path')
+const mkdir = require('make-dir')
+
+class Cache {
+	constructor({ filepath, contents }) {
+		this.filepath = filepath
+		this.data = contents
+
+		this.memcache = new Map()
+
+		if (!process.env.DOCKER) {
+			this.cacheDir = tempy.directory()
+		} else {
+			this.cacheDir = mkdir.sync('/tmp/hybsearch')
+		}
+
+		this.hashKey = this.hashKey.bind(this)
+		this.get = this.get.bind(this)
+		this.set = this.set.bind(this)
+		this._dataHash = this._hash(this.data)
+
+		this.set('source', { filepath: this.filepath, contents: this.data })
+	}
+
+	_hash(data) {
+		let hash = crypto.createHash('sha256')
+		hash.update(data)
+		return hash.digest('hex')
+	}
+
+	hashKey(key) {
+		return this._hash(`${key}:${this._dataHash}`)
+	}
+
+	diskFilename(hashedKey) {
+		return path.join(this.cacheDir, hashedKey)
+	}
+
+	get(key) {
+		key = this.hashKey(key)
+
+		if (this.memcache.has(key)) {
+			let value = this.memcache.get(key)
+			return JSON.parse(value)
+		}
+
+		try {
+			let value = fs.readFileSync(this.diskFilename(key), 'utf-8')
+			this.memcache.set(key, value)
+			return JSON.parse(value)
+		} catch (err) {
+			if (err.code === 'ENOENT') {
+				return ''
+			}
+			return ''
+		}
+	}
+
+	set(key, value) {
+		key = this.hashKey(key)
+		let serialized = JSON.stringify(value)
+		this.memcache.set(key, serialized)
+		fs.writeFileSync(this.diskFilename(key), serialized, 'utf-8')
+	}
+}
+
+module.exports = Cache

--- a/server/pipeline/hyb-pipeline
+++ b/server/pipeline/hyb-pipeline
@@ -18,38 +18,43 @@ async function main() {
 	const child = childProcess.fork(path.join(__dirname, 'worker.js'))
 
 	child.on('message', communique => {
-		let [cmd, msg] = communique
+		let { type, payload } = communique
 
-		switch (cmd) {
+		switch (type) {
 			case 'error':
-				console.error('error!', msg)
+				console.error('error!', payload.error)
 				break
 			case 'exit':
 				console.log()
 				console.log('exit')
 				break
-			case 'finish':
-				console.log('finish')
-				console.log()
-				console.log('the newick tree is below:')
-				console.log()
-				console.log(msg)
+			case 'stage-start': {
+				let { stage } = payload
+				console.log(`beginning stage: ${stage}`)
 				break
+			}
+			case 'stage-complete': {
+				let { stage, result, timeTaken } = payload
+				console.log(`completed stage: ${stage} (in ${timeTaken.toFixed(2)}ms)`)
+				console.log()
+				console.log(result)
+				break
+			}
 			default:
-				console.log(cmd, msg)
+				console.log('unknown message type', type)
 		}
 
-		if (cmd === 'error') {
+		if (type === 'error') {
 			child.disconnect()
 			process.exit(1)
 		}
 
-		if (cmd === 'exit') {
+		if (type === 'exit') {
 			child.disconnect()
 		}
 	})
 
-	child.send(['start', filepath, data])
+	child.send({ pipeline: 'search', filepath, data })
 }
 
 main()

--- a/server/pipeline/worker.js
+++ b/server/pipeline/worker.js
@@ -21,8 +21,8 @@ const send = process.send ? sendData : logData
 
 const error = e =>
 	send({ type: 'error', payload: { error: serializeError(e) } })
-const stageComplete = ({ stage, result, timeTaken }) =>
-	send({ type: 'stage-complete', payload: { stage, result, timeTaken } })
+const stageComplete = ({ stage, result, timeTaken, cached }) =>
+	send({ type: 'stage-complete', payload: { stage, result, timeTaken, cached } })
 const stageStart = ({ stage }) =>
 	send({ type: 'stage-start', payload: { stage } })
 const exit = () => send({ type: 'exit' })
@@ -160,7 +160,7 @@ async function main({ pipeline: pipelineName, filepath, data }) {
 				// instead of re-computing the results
 				outputs.forEach(([key, value]) => {
 					cache.set(key, value)
-					stageComplete({ stage: key, result: value, timeTaken: now() - start })
+					stageComplete({ stage: key, result: value, timeTaken: now() - start, cached: true })
 				})
 				start = now()
 				continue
@@ -174,7 +174,7 @@ async function main({ pipeline: pipelineName, filepath, data }) {
 				cache.set(key, result)
 
 				// send the results over the bridge
-				stageComplete({ stage: key, result, timeTaken: now() - start })
+				stageComplete({ stage: key, result, timeTaken: now() - start, cached: false })
 			})
 
 			start = now()

--- a/server/pipeline/worker.js
+++ b/server/pipeline/worker.js
@@ -22,7 +22,10 @@ const send = process.send ? sendData : logData
 const error = e =>
 	send({ type: 'error', payload: { error: serializeError(e) } })
 const stageComplete = ({ stage, result, timeTaken, cached }) =>
-	send({ type: 'stage-complete', payload: { stage, result, timeTaken, cached } })
+	send({
+		type: 'stage-complete',
+		payload: { stage, result, timeTaken, cached },
+	})
 const stageStart = ({ stage }) =>
 	send({ type: 'stage-start', payload: { stage } })
 const exit = () => send({ type: 'exit' })
@@ -160,7 +163,12 @@ async function main({ pipeline: pipelineName, filepath, data }) {
 				// instead of re-computing the results
 				outputs.forEach(([key, value]) => {
 					cache.set(key, value)
-					stageComplete({ stage: key, result: value, timeTaken: now() - start, cached: true })
+					stageComplete({
+						stage: key,
+						result: value,
+						timeTaken: now() - start,
+						cached: true,
+					})
 				})
 				start = now()
 				continue
@@ -174,7 +182,12 @@ async function main({ pipeline: pipelineName, filepath, data }) {
 				cache.set(key, result)
 
 				// send the results over the bridge
-				stageComplete({ stage: key, result, timeTaken: now() - start, cached: false })
+				stageComplete({
+					stage: key,
+					result,
+					timeTaken: now() - start,
+					cached: false,
+				})
 			})
 
 			start = now()

--- a/server/server.js
+++ b/server/server.js
@@ -29,12 +29,12 @@ wss.on('connection', ws => {
 
 	ws.on('message', communique => {
 		// when we get a message from the GUI
-		const [cmd, ...args] = JSON.parse(communique)
+		const message = JSON.parse(communique)
 
-		console.log(cmd, ...args)
+		console.log(message)
 
 		// forward the message to the pipeline
-		child.send([cmd, ...args])
+		child.send(message)
 	})
 
 	ws.on('close', () => {
@@ -47,15 +47,15 @@ wss.on('connection', ws => {
 
 	child.on('message', communique => {
 		// when we get a message from the pipeline
-		const [cmd, ...args] = communique
+		const message = communique
 
-		console.log(cmd, ...args)
+		console.log(message)
 
 		// forward the message to the GUI
-		ws.send(JSON.stringify([cmd, ...args]))
+		ws.send(JSON.stringify(message))
 
 		// detach ourselves if the pipeline has finished
-		if (cmd === 'exit' || cmd === 'error') {
+		if (message.type === 'exit' || message.type === 'error') {
 			if (child.connected) {
 				child.disconnect()
 			}


### PR DESCRIPTION
closes #74 

I don't even know what all to put here right now

This redesigns the entire pipeline structure around a declarative set of `{input, transform, output}` tuples that facilitate the automatic caching of each step's output

- You will get an array of inputs and you are expected to return an array of outputs
- The order of the `input` array is the order you will get your arguments
- The order of the `output` array is matched with the order of the returned array
- The colons serve the purpose of indicating what progress dot to fill out – everything after the colon is stripped while searching for a progress dot
- don't forget that you can specify multiple inputs and multiple outputs, and also that you can have two inputs and only generate one output
- if you need to send updated data back to the client (think the phylo graph) you can just add `:N` to the end of the step output key so you don't overwrite the prior info (in case something else wants it later)

Other things:

- The pipeline now tells the client how long each step took
- The client's websocket connection is now explicitly a global
- The newick textbox uses a second pipeline to process the newick data
- Results are cached on disk under the sha256 result of (the input/output key) + (the sha256 hash of the source input data)
- If a step used the cached data, its dot will turn green instead of blue

Todo:
- [ ] Fix the newick input box – it's broken

LMK with questions

### Example Pipeline

```js
const hybridizationSearch = [
	{
		// the first step: ensures that the input is converted to FASTA
		input: ['source'],
		transform: ([{ filepath, contents }]) =>
			filepath.endsWith('.fasta') ? [contents] : [genbankToFasta(contents)],
		output: ['initial-fasta'],
	},
	{
		// aligns the FASTA sequences
		input: ['initial-fasta'],
		transform: ([data]) => [clustal(data)],
		output: ['aligned-fasta'],
	},
	{
		// converts the aligned FASTA into Nexus
		input: ['aligned-fasta'],
		transform: ([data]) => [fastaToNexus(data)],
		output: ['aligned-nexus'],
	},
	{
		// does whatever mrbayes does
		input: ['aligned-nexus'],
		transform: ([data]) => [mrBayes(data)],
		output: ['consensus-tree'],
	},
	{
		// turns MrBayes' consensus tree into a Newick tree
		input: ['consensus-tree'],
		transform: ([data]) => [consensusTreeToNewick(data)],
		output: ['newick-tree'],
	},
	{
		// turns the Newick tree into a JSON object
		input: ['newick-tree'],
		transform: ([data]) => [parseNewick(data)],
		output: ['newick-json:1'],
	},
	{
		input: ['newick-json:1', 'aligned-fasta'],
		transform: ([newickJson, alignedFasta]) => {
			let { removedData, prunedNewick } = pruneOutliers(
				newickJson,
				alignedFasta
			)
			return [prunedNewick, removedData]
		},
		output: ['newick-json:2', 'pruned-identifiers'],
	},
	{
		// identifies the non-monophyletic sequences
		input: ['newick-json:2', 'aligned-fasta'],
		transform: ([newickJson, alignedFasta]) => [
			removeCircularLinks(ent.strictSearch(newickJson, alignedFasta)),
			removeCircularLinks(newickJson),
		],
		output: ['nonmonophyletic-sequences', 'newick-json:3'],
	},
]
```

## Before

<img width="900" alt="hybsearch with all dots green due to not caching" src="https://user-images.githubusercontent.com/464441/37858990-e2da5676-2eda-11e8-9927-4eb7225e424b.png">

## After

<img width="900" alt="hybsearch with all dots green due to caching" src="https://user-images.githubusercontent.com/464441/37858951-856e2bca-2eda-11e8-82b5-837378414f6b.png">