### PR TITLE
Reformat electron/package.json

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -26,13 +26,28 @@
     "appId": "edu.stolaf.bio.hybsearch",
     "productName": "HybSearch",
     "mac": {
-      "target": [{"target": "zip", "arch": "x64"}]
+      "target": [
+        {
+          "target": "zip",
+          "arch": "x64"
+        }
+      ]
     },
     "win": {
-      "target": [{"target": "portable", "arch": "x64"}]
+      "target": [
+        {
+          "target": "portable",
+          "arch": "x64"
+        }
+      ]
     },
     "linux": {
-      "target": [{"target": "tar.gz", "arch": "x64"}],
+      "target": [
+        {
+          "target": "tar.gz",
+          "arch": "x64"
+        }
+      ],
       "category": "Education"
     },
     "files": [

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:8-stretch
+FROM docker.io/amd64/node:8-stretch
 
 # enable non-free repos, needed for seq-gen
 RUN sed -i 's|deb http://deb.debian.org/debian stretch main|deb http://http.us.debian.org/debian stretch main non-free|' /etc/apt/sources.list


### PR DESCRIPTION
npm did this by itself, and I'd rather not have this be unstaged and floating around... so, yeah.  I can't think of any reason (besides the extra SLoC induced by formatting it this way) to not do this.

Currently red in CI because of https://github.com/nodejs/docker-node/issues/675.  Will kick off the rebuild once that tag is present upstream.

Blocked by #83. (Safe to close #83 if this PR gets merged instead.)