### PR TITLE
Declaratively specify that we would like to use amd64 node images

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:8-stretch
+FROM docker.io/amd64/node:8-stretch
 
 # enable non-free repos, needed for seq-gen
 RUN sed -i 's|deb http://deb.debian.org/debian stretch main|deb http://http.us.debian.org/debian stretch main non-free|' /etc/apt/sources.list


### PR DESCRIPTION
While I extol the virtues of multiarch builds, our app primarily targets amd64 devices, and I'm pretty sure we can only build on amd64 infrastructure.

As such, we should specify that in our Dockerfile.  This prevents outages like what happened with nodejs/docker-node#675, because instead of having to deal with issues such as amd64 images getting lost out of the manifest on Docker Hub, we just use whichever version is available for our specific architecture, and those only have one architecture in their manifest.  This issue was the result of a race condition: as soon as an arcane architecture finished building, the new docker image would get pushed, and then the Docker Hub manifests would get updated to only include that new architecture.

This commit switches to a side repository that only contains the amd64 builds, which should resolve the issue until the greater issue at hand, docker-library/official-images#3835, is solved.  This repository is where stuff gets pushed from the same community repository.

I'd imagine a build matrix would have to be established if we wanted to use additional architectures, anyhow, since there might be some customization required, as noted in #82.

Closes #82.