### PR TITLE
List pipelines dynamically from the server

### DIFF
--- a/electron/index.html
+++ b/electron/index.html
@@ -26,6 +26,11 @@
 				<button id="use-thing3" data-url="ws://thing3.cs.stolaf.edu:80/">Use Thing3</button>
 				<button id="use-localhost" data-url="ws://localhost:8080/">Use localhost</button>
 				<br/><br/>
+				<label for="pick-pipeline">Pipeline:</label>
+				<select id="pick-pipeline">
+					<option>No pipelines present</option>
+				</select>
+				<br/><br/>
 				<button id="start">Run Hybsearch</button>
 			</wrapper>
 			<wrapper class="loading">

--- a/electron/index.html
+++ b/electron/index.html
@@ -29,34 +29,6 @@
 				<button id="start">Run Hybsearch</button>
 			</wrapper>
 			<wrapper class="loading">
-				<div class="checkmark" data-loader-name="initial-fasta">
-					<div class="icon"></div>
-					<div class="label">Process Input</div>
-				</div>
-				<div class="checkmark" data-loader-name="aligned-fasta">
-					<div class="icon"></div>
-					<div class="label">Align Sequences</div>
-				</div>
-				<div class="checkmark" data-loader-name="aligned-nexus">
-					<div class="icon"></div>
-					<div class="label">Convert Alignment</div>
-				</div>
-				<div class="checkmark" data-loader-name="consensus-tree">
-					<div class="icon"></div>
-					<div class="label">Generate Tree</div>
-				</div>
-				<div class="checkmark" data-loader-name="newick-tree">
-					<div class="icon"></div>
-					<div class="label">Render Tree</div>
-				</div>
-				<div class="checkmark" data-loader-name="newick-json">
-					<div class="icon"></div>
-					<div class="label">Parsing Newick</div>
-				</div>
-				<div class="checkmark" data-loader-name="nonmonophyletic-sequences">
-					<div class="icon"></div>
-					<div class="label">Running Ent</div>
-				</div>
 			</wrapper>
 		</section>
 

--- a/electron/run.js
+++ b/electron/run.js
@@ -38,7 +38,8 @@ function submitJob({ socket = global.socket, pipeline, filepath, data }) {
 		throw new Error('socket not ready!')
 	}
 
-	ws.send(JSON.stringify({ pipeline, filepath, data }), err => {
+	let payload = { type: 'start', pipeline, filepath, data }
+	ws.send(JSON.stringify(payload), err => {
 		if (err) {
 			console.error('server error', err)
 			window.alert('server error:', err.message)
@@ -74,11 +75,11 @@ function onMessage(packet) {
 
 	if (type === 'stage-start') {
 		const { stage } = payload
-		beginLoadingStatus(stage.split(':')[0])
+		beginLoadingStatus(stage)
 	} else if (type === 'stage-complete') {
 		const { stage, timeTaken, result, cached } = payload
 		updateLoadingStatus({
-			label: stage.split(':')[0],
+			label: stage,
 			duration: timeTaken.toFixed(2),
 			usedCache: cached,
 		})

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -76,9 +76,7 @@ function connectionIsUp() {
 				.join('')
 
 			getSteps(pipelines[0])
-			el.addEventListener('change', ev =>
-				getSteps(ev.currentTarget.value)
-			)
+			el.addEventListener('change', ev => getSteps(ev.currentTarget.value))
 		} else if (data.type === 'pipeline-steps') {
 			let payload = JSON.parse(data.payload)
 

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -3,6 +3,7 @@
 const groupBy = require('lodash/groupBy')
 const mapValues = require('lodash/mapValues')
 const toPairs = require('lodash/toPairs')
+const uniq = require('lodash/uniq')
 const getFiles = require('./lib/get-files')
 const { attachListeners } = require('./run')
 
@@ -45,6 +46,14 @@ document.querySelector('#server-url').addEventListener('change', ev => {
 	updateWebSocket(ev.currentTarget.value)
 })
 
+const getSteps = pipeline =>
+	global.socket.send(
+		JSON.stringify({
+			type: 'pipeline-steps',
+			pipeline: pipeline,
+		})
+	)
+
 function connectionIsUp() {
 	document.querySelector('#server-status').classList.remove('down')
 	document.querySelector('#server-status').classList.add('up')
@@ -64,6 +73,30 @@ function connectionIsUp() {
 			let el = document.querySelector('#pick-pipeline')
 			el.innerHTML = pipelines
 				.map(name => `<option value="${name}">${name}</option>`)
+				.join('')
+
+			getSteps(pipelines[0])
+			el.addEventListener('change', ev =>
+				getSteps(ev.currentTarget.value)
+			)
+		} else if (data.type === 'pipeline-steps') {
+			let payload = JSON.parse(data.payload)
+
+			let steps = uniq(
+				payload
+					.map(segment => [...segment.input, ...segment.output])
+					.reduce((acc, item) => [...acc, ...item], [])
+			)
+
+			let el = document.querySelector('wrapper.loading')
+			el.innerHTML = steps
+				.map(
+					stage =>
+						`<div class="checkmark" data-loader-name="${stage}">
+							<div class="icon"></div>
+							<div class="label">${stage}</div>
+						</div>`
+				)
 				.join('')
 		}
 	})

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -48,11 +48,41 @@ document.querySelector('#server-url').addEventListener('change', ev => {
 function connectionIsUp() {
 	document.querySelector('#server-status').classList.remove('down')
 	document.querySelector('#server-status').classList.add('up')
+
+	global.socket.send(JSON.stringify({ type: 'pipeline-list' }), err => {
+		if (err) {
+			console.error('server error', err)
+			window.alert('server error:', err.message)
+		}
+	})
+
+	global.socket.addEventListener('message', ({ data }) => {
+		data = JSON.parse(data)
+		if (data.type === 'pipeline-list') {
+			let pipelines = JSON.parse(data.payload)
+
+			let el = document.querySelector('#pick-pipeline')
+			el.innerHTML = pipelines
+				.map(name => `<option value="${name}">${name}</option>`)
+				.join('')
+		}
+	})
+
+	global.socket.addEventListener('disconnect', (...args) =>
+		console.log('disconnect', ...args)
+	)
+
+	global.socket.addEventListener('error', (...args) =>
+		console.log('error', ...args)
+	)
 }
 
 function connectionRefused() {
 	document.querySelector('#server-status').classList.remove('up')
 	document.querySelector('#server-status').classList.add('down')
+
+	// TODO: rework connectionIsUp/connectionRefused to remove the
+	// event listeners when the socket changes
 }
 
 const files = getFiles()

--- a/server/pipeline/lib.js
+++ b/server/pipeline/lib.js
@@ -1,0 +1,10 @@
+module.exports.removeCircularLinks = function(obj) {
+	return JSON.parse(
+		JSON.stringify(obj, function(key, val) {
+			if (['parent', 'nmInner', 'nmOuter'].includes(key)) {
+				return undefined
+			}
+			return val
+		})
+	)
+}

--- a/server/pipeline/pipelines/index.js
+++ b/server/pipeline/pipelines/index.js
@@ -1,0 +1,4 @@
+'use strict'
+
+module.exports.search = require('./search.js')
+module.exports['parse-newick'] = require('./parse-newick.js')

--- a/server/pipeline/pipelines/parse-newick.js
+++ b/server/pipeline/pipelines/parse-newick.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { parse: parseNewick } = require('../../newick')
+
+module.exports = [
+	{
+		// turns the Newick tree into a JSON object
+		input: ['source'],
+		transform: ([data]) => [parseNewick(data)],
+		output: ['newick-json:1'],
+	},
+]

--- a/server/pipeline/pipelines/search.js
+++ b/server/pipeline/pipelines/search.js
@@ -13,9 +13,7 @@ module.exports = [
 		// the first step: ensures that the input is converted to FASTA
 		input: ['source'],
 		transform: ([{ filepath, contents }]) =>
-			filepath.endsWith('.fasta')
-				? [contents]
-				: [genbankToFasta(contents)],
+			filepath.endsWith('.fasta') ? [contents] : [genbankToFasta(contents)],
 		output: ['initial-fasta'],
 	},
 	{

--- a/server/pipeline/pipelines/search.js
+++ b/server/pipeline/pipelines/search.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const ent = require('../../ent')
+const { consensusTreeToNewick, parse: parseNewick } = require('../../newick')
+const { genbankToFasta, fastaToNexus } = require('../../formats')
+const { pruneOutliers } = require('../../lib/prune-newick')
+const clustal = require('../../wrappers/clustal')
+const mrBayes = require('../../wrappers/mrbayes')
+const { removeCircularLinks } = require('../lib')
+
+module.exports = [
+	{
+		// the first step: ensures that the input is converted to FASTA
+		input: ['source'],
+		transform: ([{ filepath, contents }]) =>
+			filepath.endsWith('.fasta')
+				? [contents]
+				: [genbankToFasta(contents)],
+		output: ['initial-fasta'],
+	},
+	{
+		// aligns the FASTA sequences
+		input: ['initial-fasta'],
+		transform: ([data]) => [clustal(data)],
+		output: ['aligned-fasta'],
+	},
+	{
+		// converts the aligned FASTA into Nexus
+		input: ['aligned-fasta'],
+		transform: ([data]) => [fastaToNexus(data)],
+		output: ['aligned-nexus'],
+	},
+	{
+		// does whatever mrbayes does
+		input: ['aligned-nexus'],
+		transform: ([data]) => [mrBayes(data)],
+		output: ['consensus-tree'],
+	},
+	{
+		// turns MrBayes' consensus tree into a Newick tree
+		input: ['consensus-tree'],
+		transform: ([data]) => [consensusTreeToNewick(data)],
+		output: ['newick-tree'],
+	},
+	{
+		// turns the Newick tree into a JSON object
+		input: ['newick-tree'],
+		transform: ([data]) => [parseNewick(data)],
+		output: ['newick-json:1'],
+	},
+	{
+		input: ['newick-json:1', 'aligned-fasta'],
+		transform: ([newickJson, alignedFasta]) => {
+			let { removedData, prunedNewick } = pruneOutliers(
+				newickJson,
+				alignedFasta
+			)
+			return [prunedNewick, removedData]
+		},
+		output: ['newick-json:2', 'pruned-identifiers'],
+	},
+	{
+		// identifies the non-monophyletic sequences
+		input: ['newick-json:2', 'aligned-fasta'],
+		transform: ([newickJson, alignedFasta]) => [
+			removeCircularLinks(ent.strictSearch(newickJson, alignedFasta)),
+			removeCircularLinks(newickJson),
+		],
+		output: ['nonmonophyletic-sequences', 'newick-json:3'],
+	},
+]

--- a/server/pipeline/worker.js
+++ b/server/pipeline/worker.js
@@ -4,12 +4,7 @@ const serializeError = require('serialize-error')
 
 const Cache = require('./cache')
 const zip = require('lodash/zip')
-const ent = require('../ent')
-const { consensusTreeToNewick, parse: parseNewick } = require('../newick')
-const { genbankToFasta, fastaToNexus } = require('../formats')
-const { pruneOutliers } = require('../lib/prune-newick')
-const clustal = require('../wrappers/clustal')
-const mrBayes = require('../wrappers/mrbayes')
+const PIPELINES = require('./pipelines')
 
 /////
 ///// helpers
@@ -29,17 +24,6 @@ const stageComplete = ({ stage, result, timeTaken, cached }) =>
 const stageStart = ({ stage }) =>
 	send({ type: 'stage-start', payload: { stage } })
 const exit = () => send({ type: 'exit' })
-
-function removeCircularLinks(obj) {
-	return JSON.parse(
-		JSON.stringify(obj, function(key, val) {
-			if (['parent', 'nmInner', 'nmOuter'].includes(key)) {
-				return undefined
-			}
-			return val
-		})
-	)
-}
 
 const now = () => {
 	let time = process.hrtime()
@@ -68,79 +52,6 @@ process.on('disconnect', () => {
 ///// pipeline
 /////
 
-const hybridizationSearch = [
-	{
-		// the first step: ensures that the input is converted to FASTA
-		input: ['source'],
-		transform: ([{ filepath, contents }]) =>
-			filepath.endsWith('.fasta') ? [contents] : [genbankToFasta(contents)],
-		output: ['initial-fasta'],
-	},
-	{
-		// aligns the FASTA sequences
-		input: ['initial-fasta'],
-		transform: ([data]) => [clustal(data)],
-		output: ['aligned-fasta'],
-	},
-	{
-		// converts the aligned FASTA into Nexus
-		input: ['aligned-fasta'],
-		transform: ([data]) => [fastaToNexus(data)],
-		output: ['aligned-nexus'],
-	},
-	{
-		// does whatever mrbayes does
-		input: ['aligned-nexus'],
-		transform: ([data]) => [mrBayes(data)],
-		output: ['consensus-tree'],
-	},
-	{
-		// turns MrBayes' consensus tree into a Newick tree
-		input: ['consensus-tree'],
-		transform: ([data]) => [consensusTreeToNewick(data)],
-		output: ['newick-tree'],
-	},
-	{
-		// turns the Newick tree into a JSON object
-		input: ['newick-tree'],
-		transform: ([data]) => [parseNewick(data)],
-		output: ['newick-json:1'],
-	},
-	{
-		input: ['newick-json:1', 'aligned-fasta'],
-		transform: ([newickJson, alignedFasta]) => {
-			let { removedData, prunedNewick } = pruneOutliers(
-				newickJson,
-				alignedFasta
-			)
-			return [prunedNewick, removedData]
-		},
-		output: ['newick-json:2', 'pruned-identifiers'],
-	},
-	{
-		// identifies the non-monophyletic sequences
-		input: ['newick-json:2', 'aligned-fasta'],
-		transform: ([newickJson, alignedFasta]) => [
-			removeCircularLinks(ent.strictSearch(newickJson, alignedFasta)),
-			removeCircularLinks(newickJson),
-		],
-		output: ['nonmonophyletic-sequences', 'newick-json:3'],
-	},
-]
-
-const parseNewickFile = [
-	{
-		// turns the Newick tree into a JSON object
-		input: ['source'],
-		transform: ([data]) => [parseNewick(data)],
-		output: ['newick-json:1'],
-	},
-]
-
-const PIPELINES = {
-	search: hybridizationSearch,
-	'parse-newick': parseNewickFile,
-}
 
 // eslint-disable-next-line no-unused-vars
 async function main({ pipeline: pipelineName, filepath, data }) {

--- a/server/pipeline/worker.js
+++ b/server/pipeline/worker.js
@@ -52,10 +52,22 @@ process.on('disconnect', () => {
 ///// pipeline
 /////
 
-
-// eslint-disable-next-line no-unused-vars
-async function main({ pipeline: pipelineName, filepath, data }) {
+async function main({ pipeline: pipelineName, filepath, data, type }) {
 	let start = now()
+
+	if (type === 'pipeline-list') {
+		send({
+			type: 'pipeline-list',
+			payload: JSON.stringify(Object.keys(PIPELINES)),
+		})
+		return
+	} else if (type === 'pipeline-steps') {
+		send({
+			type: 'pipeline-steps',
+			payload: JSON.stringify(PIPELINES[pipelineName]),
+		})
+		return
+	}
 
 	try {
 		let cache = new Cache({ filepath, contents: data })


### PR DESCRIPTION
With this PR, the server can give you the list of supported pipelines.

This will allow us to support both the BEAST and the MrBayes pipelines while we investigate BEAST.

<img width="658" alt="screen shot 2018-04-03 at 10 27 13 pm" src="https://user-images.githubusercontent.com/464441/38287055-2c244880-378e-11e8-913d-d4405608d8f7.png">

The loading dots are now dynamically provided by the selected pipeline, as well.

![screen shot 2018-04-03 at 10 26 41 pm](https://user-images.githubusercontent.com/464441/38287043-180fdecc-378e-11e8-942e-e1f33bac69da.png)