### PR TITLE
Format the step durations

### DIFF
--- a/electron/index.css
+++ b/electron/index.css
@@ -129,7 +129,7 @@ section.loader.loading wrapper.content {
 
 .loader .checkmark[data-time]::after {
 	font-size: 0.85em;
-	content: attr(data-time) 'ms';
+	content: attr(data-time);
 }
 
 #phylogram {

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1234,6 +1234,11 @@
         }
       }
     },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1649,6 +1654,11 @@
         "error-ex": "1.3.1"
       }
     },
+    "parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -1708,6 +1718,14 @@
         "pinkie": "2.0.4"
       }
     },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "requires": {
+        "irregular-plurals": "1.4.0"
+      }
+    },
     "pretty-bytes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
@@ -1716,6 +1734,15 @@
       "requires": {
         "get-stdin": "4.0.1",
         "meow": "3.7.0"
+      }
+    },
+    "pretty-ms": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
+      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+      "requires": {
+        "parse-ms": "1.0.1",
+        "plur": "2.1.2"
       }
     },
     "process-nextick-args": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -64,7 +64,8 @@
     "electron-updater": "^2.21.1",
     "lodash": "^4.17.5",
     "loud-rejection": "^1.6.0",
-    "normalize.css": "^7.0.0"
+    "normalize.css": "^7.0.0",
+    "pretty-ms": "^3.1.0"
   },
   "devDependencies": {
     "electron": "^1.8.3",

--- a/electron/run.js
+++ b/electron/run.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { load, setEntResults } = require('./graph')
-
+const prettyMs = require('pretty-ms')
 const fs = require('fs')
 
 function run() {
@@ -84,7 +84,7 @@ function onMessage(packet) {
 		const { stage, timeTaken, result, cached } = payload
 		updateLoadingStatus({
 			label: stage,
-			duration: timeTaken.toFixed(2),
+			duration: timeTaken,
 			usedCache: cached,
 		})
 		onData(stage, result)
@@ -141,7 +141,7 @@ function updateLoadingStatus({ label, duration, usedCache }) {
 	el.classList.remove('active')
 	el.classList.add('complete')
 	usedCache && el.classList.add('used-cache')
-	el.dataset.time = duration
+	el.dataset.time = prettyMs(duration)
 }
 
 function beginLoadingStatus(label) {


### PR DESCRIPTION
It lets them look like this, with the units changing from "ms" always to "seconds" and even "minutes".

<img width="562" alt="image" src="https://user-images.githubusercontent.com/464441/38397914-cd1731f8-3905-11e8-8c2b-ccf06fc337ce.png">
