### PR TITLE
Split app building step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,13 @@ workflows:
           requires: [lint, test-server, test-pipeline-beast, test-pipeline-mrbayes, test-app]
           filters: *filters
           context: docker-hub
-      - deploy-github:
+      - build-app-windows:
+          requires: [lint, test-server, test-pipeline-beast, test-pipeline-mrbayes, test-app]
+          filters: *filters
+      - build-app-mac:
+          requires: [lint, test-server, test-pipeline-beast, test-pipeline-mrbayes, test-app]
+          filters: *filters
+      - build-app-linux:
           requires: [lint, test-server, test-pipeline-beast, test-pipeline-mrbayes, test-app]
           filters: *filters
 
@@ -204,7 +210,7 @@ jobs:
             fi
 
   # deploy the compiled electron binaries to GitHub Releases
-  deploy-github: &electron-builder-base
+  build-app-windows: &electron-builder-base
     <<: *defaults
     docker:
       - image: electronuserland/builder:wine
@@ -215,17 +221,6 @@ jobs:
       - run: &electron-pkg-version
           name: Update the electron package version number
           command: node -e 'let ver=require("./package.json").version;let ePth="./electron/package.json";let electronPkg=require(ePth);electronPkg.version=ver;fs.writeFileSync(ePth, JSON.stringify(electronPkg), "utf-8")'
-      - run: cd electron && npm install --production
-      - run: cd electron && npm run build
-
-  # deploy the compiled electron binaries to GitHub Releases
-  build-app-windows:
-    <<: *electron-builder-base
-    steps:
-      - checkout:
-          path: /root/project
-      - run: *install-electron-builder
-      - run: *electron-pkg-version
       - run: cd electron && npm install --production
       - run: cd electron && npm run build:setup
       - run: cd electron && electron-builder --windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,12 @@ workflows:
       - deploy-docker:
           requires: [lint, test-server, test-pipeline-beast, test-pipeline-mrbayes, test-app]
           context: docker-hub
-      - deploy-github:
-          requires: [lint, test-server, test-pipeline-beast, test-pipeline-mrbayes, test-app]
+      - build-app-windows:
+          requires: [lint, test-app]
+      - build-app-mac:
+          requires: [lint, test-app]
+      - build-app-linux:
+          requires: [lint, test-app]
 
   on_tag:
     jobs:
@@ -200,16 +204,50 @@ jobs:
             fi
 
   # deploy the compiled electron binaries to GitHub Releases
-  deploy-github:
+  deploy-github: &electron-builder-base
     <<: *defaults
     docker:
       - image: electronuserland/builder:wine
     steps:
       - checkout:
           path: /root/project
-      - run: npm i -g electron-builder parcel-bundler
-      - run:
+      - run: &install-electron-builder npm i -g electron-builder parcel-bundler
+      - run: &electron-pkg-version
           name: Update the electron package version number
           command: node -e 'let ver=require("./package.json").version;let ePth="./electron/package.json";let electronPkg=require(ePth);electronPkg.version=ver;fs.writeFileSync(ePth, JSON.stringify(electronPkg), "utf-8")'
       - run: cd electron && npm install --production
       - run: cd electron && npm run build
+
+  # deploy the compiled electron binaries to GitHub Releases
+  build-app-windows:
+    <<: *electron-builder-base
+    steps:
+      - checkout:
+          path: /root/project
+      - run: *install-electron-builder
+      - run: *electron-pkg-version
+      - run: cd electron && npm install --production
+      - run: cd electron && npm run build:setup
+      - run: cd electron && electron-builder --windows
+
+  build-app-mac:
+    <<: *electron-builder-base
+    steps:
+      - checkout:
+          path: /root/project
+      - run: *install-electron-builder
+      - run: *electron-pkg-version
+      - run: cd electron && npm install --production
+      - run: cd electron && npm run build:setup
+      - run: cd electron && electron-builder --macos
+
+  build-app-linux:
+    <<: *electron-builder-base
+    steps:
+      - checkout:
+          path: /root/project
+      - run: *install-electron-builder
+      - run: *electron-pkg-version
+      - run: cd electron && npm install --production
+      - run: cd electron && npm run build:setup
+      - run: cd electron && electron-builder --linux

--- a/electron/package.json
+++ b/electron/package.json
@@ -9,7 +9,8 @@
   "author": "The Hybsearch Team <hybsearch@stolaf.edu>",
   "main": "main.js",
   "scripts": {
-    "build": "npm run clean && npm run build:copy && npm run build:js && npm run build:css && npm run build:app",
+    "build": "npm run build:setup && npm run build:app",
+    "build:setup": "npm run clean && npm run build:copy && npm run build:js && npm run build:css",
     "build:app": "electron-builder --macos --windows --linux",
     "build:copy": "mkdir -p out/data && cp -v index.html index.css out/ && cp -rv ../data/*.gb out/data/",
     "build:css": "parcel build -t electron --no-minify --detailed-report --out-dir out index.css",


### PR DESCRIPTION
This lets the app building take place in parallel, which lets the average overall build time of 9m43s drop to 7m16s.

I think. Probably.

If it gets really slow, we can always revert it and go back to the single build step.