### PR TITLE
Add JML binaries to Docker image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -29,6 +29,8 @@ COPY --from=hyb-beast ["/beast/beast/bin/beast", "/usr/local/bin/"]
 COPY --from=hyb-beast ["/beast/beast/lib/beast.jar", "/usr/local/lib/"]
 COPY --from=hyb-beast ["/beast/beast/lib/launcher.jar", "/usr/local/lib/"]
 
+COPY --from=hyb-jml ["/usr/local/bin/jml", "/usr/local/bin/"]
+
 RUN sed -i 's|deb http://deb.debian.org/debian stretch main|deb http://http.us.debian.org/debian stretch main non-free|' /etc/apt/sources.list
 
 # fixes issue with installing openjdk-8-jdk-headless

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker.io/amd64/node:8-stretch AS hyb-node
 
+FROM docker.io/hybsearch/jml:v1.3.1-hyb.1 AS hyb-jml
+
 FROM hybsearch/docker-base:v1.4 AS hyb-beast
 
 RUN mkdir -p /usr/share/man/man1/


### PR DESCRIPTION
This shouldn't have too much of an impact on the overall Docker image size besides adding a teensy layer.  I don't think we have to copy any libraries or stuff over, because JML is pretty much standalone.

Part of #99.