### PR TITLE
New Algorithm for Pruning Outliers

### DIFF
--- a/electron/index.html
+++ b/electron/index.html
@@ -44,7 +44,7 @@
 
 		<section hidden id="omitted-container">
 			<h2>Omitted Sequences</h2>
-			<p>The following sequences were omitted because their distances to all other pairs was above average for a majority of the pairs. </p>
+			<p>The following sequences were omitted because they were more than 50% different to a majority of the sequences. </p>
 			<div id="omitted-results"></div>
 		</section>
 

--- a/electron/index.html
+++ b/electron/index.html
@@ -44,7 +44,7 @@
 
 		<section hidden id="omitted-container">
 			<h2>Omitted Sequences</h2>
-			<p>The following sequences were omitted because they were more than 50% different to a majority of the sequences. </p>
+			<p>The following sequences were omitted because they were more than 20% different to a majority of the sequences. </p>
 			<div id="omitted-results"></div>
 		</section>
 

--- a/electron/run.js
+++ b/electron/run.js
@@ -105,7 +105,7 @@ function onData(phase, data) {
 		document.querySelector('#phylogram').hidden = false
 		load(data)
 	} else if (phase === 'pruned-identifiers') {
-		let container = document.querySelector('#omitted-results')
+		let container = document.querySelector('#omitted-container')
 
 		let formattedNames = data.map(node => {
 			let ident = node.ident ? ` [${node.ident}]` : ''

--- a/electron/run.js
+++ b/electron/run.js
@@ -113,8 +113,6 @@ function onData(phase, data) {
 			return `${node.name}${ident} (${node.length})`
 		})
 
-		results.innerHTML = `<pre>${formattedNames.join('\n')}</pre>`
-		container.hidden = false
 		if (formattedNames.length > 0) {
 			results.innerHTML = `<pre>${formattedNames.join('\n')}</pre>`
 			container.hidden = false

--- a/electron/run.js
+++ b/electron/run.js
@@ -106,13 +106,14 @@ function onData(phase, data) {
 		load(data)
 	} else if (phase === 'pruned-identifiers') {
 		let container = document.querySelector('#omitted-container')
+		let results = document.querySelector("#omitted-results")
 
 		let formattedNames = data.map(node => {
 			let ident = node.ident ? ` [${node.ident}]` : ''
 			return `${node.name}${ident} (${node.length})`
 		})
 
-		container.innerHTML = `<pre>${formattedNames.join('\n')}</pre>`
+		results.innerHTML = `<pre>${formattedNames.join('\n')}</pre>`
 		container.hidden = false
 	} else if (phase === 'jml-output') {
 		let container = document.querySelector('#jml-container')

--- a/electron/run.js
+++ b/electron/run.js
@@ -106,7 +106,7 @@ function onData(phase, data) {
 		load(data)
 	} else if (phase === 'pruned-identifiers') {
 		let container = document.querySelector('#omitted-container')
-		let results = document.querySelector("#omitted-results")
+		let results = document.querySelector('#omitted-results')
 
 		let formattedNames = data.map(node => {
 			let ident = node.ident ? ` [${node.ident}]` : ''
@@ -115,6 +115,10 @@ function onData(phase, data) {
 
 		results.innerHTML = `<pre>${formattedNames.join('\n')}</pre>`
 		container.hidden = false
+		if (formattedNames.length > 0) {
+			results.innerHTML = `<pre>${formattedNames.join('\n')}</pre>`
+			container.hidden = false
+		}
 	} else if (phase === 'jml-output') {
 		let container = document.querySelector('#jml-container')
 
@@ -135,8 +139,6 @@ function onData(phase, data) {
 		document
 			.querySelector('#results')
 			.appendChild(makeTableFromObject(data.results))
-
-		container.hidden = false
 	} else if (phase === 'nonmonophyletic-sequences') {
 		setEntResults(data)
 	} else {

--- a/server/lib/prune-newick.js
+++ b/server/lib/prune-newick.js
@@ -36,10 +36,9 @@ function pruneOutliers(newick, alignedFasta) {
 		distCache[i] = {}
 		// Compute actual gene length
 		geneLength[i] = 0
-		for (let k = 0; k < sequenceMap[species1].length; k++) {
-			let seq = sequenceMap[species1]
+		for (let seq of sequenceMap[species1]) {
 			if (seq[k] !== '-') {
-				geneLength[i]++
+				geneLength[i]+=1
 			}
 		}
 
@@ -74,9 +73,9 @@ function pruneOutliers(newick, alignedFasta) {
 			let gene2 = geneLength[j]
 			// The hamming distance can be at most the size of the smaller sequence
 			// So to get the proportion, we divide it by the length of the smalle sequence
-			let smallerGeneLength = gene1 < gene2 ? gene1 : gene2
+			let smallerGeneLength = Math.min(gene1,gene2)
 			let diffProportion = hammingDistance / smallerGeneLength
-			console.log(diffProportion)
+
 			if (diffProportion > 0.2) {
 				diffCount++
 			}

--- a/server/lib/prune-newick.js
+++ b/server/lib/prune-newick.js
@@ -38,7 +38,7 @@ function pruneOutliers(newick, alignedFasta) {
 		geneLength[i] = 0
 		for (let seq of sequenceMap[species1]) {
 			if (seq[k] !== '-') {
-				geneLength[i]+=1
+				geneLength[i] += 1
 			}
 		}
 
@@ -73,7 +73,7 @@ function pruneOutliers(newick, alignedFasta) {
 			let gene2 = geneLength[j]
 			// The hamming distance can be at most the size of the smaller sequence
 			// So to get the proportion, we divide it by the length of the smalle sequence
-			let smallerGeneLength = Math.min(gene1,gene2)
+			let smallerGeneLength = Math.min(gene1, gene2)
 			let diffProportion = hammingDistance / smallerGeneLength
 
 			if (diffProportion > 0.2) {

--- a/server/lib/prune-newick.js
+++ b/server/lib/prune-newick.js
@@ -36,8 +36,9 @@ function pruneOutliers(newick, alignedFasta) {
 		distCache[i] = {}
 		// Compute actual gene length
 		geneLength[i] = 0
-		for (let seq of sequenceMap[species1]) {
-			if (seq[k] !== '-') {
+
+		for (let letter of sequenceMap[species1]) {
+			if (letter !== '-') {
 				geneLength[i] += 1
 			}
 		}


### PR DESCRIPTION
The new algorithm as requested by Steve is:

_A sequence is removed if it is more than X% different from a majority of the other sequences, or if its length is less than Y_

We had talked about `X` being 50% but I ended up finding that 20% works better. And the cut off Y is a constant set at 300 currently. 

Here is a screenshot from running `pseudemyscytbplushnfal.fasta`

![pseude](https://puu.sh/A0xqm/353afd156d.png)

And from running `trio171seqshortaln.fasta`

![trio171](https://puu.sh/A0xnR/9d9b9901e5.png)

I'd like to get this merged soon so that the biologists can run some tests and verify these constants. 