### PR TITLE
Release v4.0.0, beta 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybsearch/hybsearch",
-  "version": "4.0.0-beta.13",
+  "version": "4.0.0-beta.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybsearch/hybsearch",
   "private": true,
-  "version": "4.0.0-beta.13",
+  "version": "4.0.0-beta.14",
   "description": "Find nonmonophyly in genetic sequences",
   "repository": "hybsearch/hybsearch",
   "homepage": "https://hybsearch.github.io/",


### PR DESCRIPTION
This release adds @OmarShehata's new outlier pruning algorithm from #104.

Edit: draft of the email…

---

Hey y'all,

–––

First off, Omar's finished his new outlier pruning algorithm:

> The new algorithm as requested by Steve is:
> 
> > A sequence is removed if it is more than X% different from a majority of the other sequences, or if its length is less than Y
> 
> We had talked about X being 50% but I ended up finding that 20% works better. And the cut off Y is a constant set at 300 currently.

So that's a thing! 👏👏👏

–––

Second, Kris and I finished the "mbnb" pipeline we were talking about in the Beta12 email last night.

What it does is to align the sequences, as usual, but then we run those aligned sequences through MrBayes to get our consensus tree, which we then send through Ent to find the initial set of non-monophyletic individuals.

We then take that set of individuals and remove them from the aligned FASTA file, leaving us with just the maybe-monophyletic peeps.

Finally, we take that set of sequences and feed it to BEAST, which empties into JML, which gives us the p-values or something idk.

Then we render those JML results in the main interface, underneath the phylogram graph.

–––

If you need to run one of the previous pipelines for any reason, there's a Pipeline dropdown that lets you pick between mbnb, beast, and search (the classic mrbayes-only pipeline).

–––

Anyway, if you all could test out the MBNB pipeline with some of the input files and see if the outputs look correct, that'd be great?

The graph doesn't update after JML runs, so you'll have to look at the Results table to see the results.

Happy hunting,
– Hawken