### PR TITLE
Shrink beast iterations to 1M

### DIFF
--- a/server/formats/__tests__/__snapshots__/fasta-to-beast.test.js.snap
+++ b/server/formats/__tests__/__snapshots__/fasta-to-beast.test.js.snap
@@ -26,7 +26,7 @@ exports[`emydura-short.fasta 1`] = `
 <map name=\\"InverseGamma\\">beast.math.distributions.InverseGamma</map>
 <map name=\\"OneOnX\\">beast.math.distributions.OneOnX</map>
 
-<run id=\\"mcmc\\" spec=\\"MCMC\\" chainLength=\\"10000000\\" storeEvery=\\"5000\\">
+<run id=\\"mcmc\\" spec=\\"MCMC\\" chainLength=\\"1000000\\" storeEvery=\\"5000\\">
 	<state id=\\"state\\" storeEvery=\\"5000\\">
 		<parameter id=\\"popSize\\" name=\\"stateNode\\">1.0</parameter>
 		<tree id=\\"Tree.t:Species\\" name=\\"stateNode\\">

--- a/server/formats/template.xml
+++ b/server/formats/template.xml
@@ -16,7 +16,7 @@
 <map name="InverseGamma">beast.math.distributions.InverseGamma</map>
 <map name="OneOnX">beast.math.distributions.OneOnX</map>
 
-<run id="mcmc" spec="MCMC" chainLength="10000000" storeEvery="5000">
+<run id="mcmc" spec="MCMC" chainLength="1000000" storeEvery="5000">
 	<state id="state" storeEvery="5000">
 		<parameter id="popSize" name="stateNode">1.0</parameter>
 		<tree id="Tree.t:Species" name="stateNode">


### PR DESCRIPTION
Closes #112 

For now, we're going to go with 1M iterations. Later one, especially once we've parallelized this, we may look at increasing it to see what effects that has, but that's in the future.