### PR TITLE
use grid layout on the progress bar

### DIFF
--- a/electron/index.css
+++ b/electron/index.css
@@ -51,9 +51,10 @@ section.loader wrapper.loading {
 	display: none;
 }
 section.loader.loading wrapper.loading {
-	display: flex;
-	justify-content: space-around;
-	flex-wrap: wrap;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(125px, 1fr));
+	grid-row-gap: 0.5rem;
+	grid-column-gap: 0.25rem;
 }
 section.loader.loading wrapper.content {
 	display: none;


### PR DESCRIPTION
I think it looks much nicer

| Before |
| --- |
| <img width="450" alt="screen shot 2018-04-11 at 5 25 25 pm" src="https://user-images.githubusercontent.com/464441/38646373-56ced5c6-3dad-11e8-8b34-0ff721f07d14.png"> |
| After |
| <img width="450" alt="screen shot 2018-04-11 at 5 25 28 pm" src="https://user-images.githubusercontent.com/464441/38646379-58a29f36-3dad-11e8-8735-b381863a5dea.png"> |
