### PR TITLE
Revert "Shrink beast iterations to 1M"

### DIFF
--- a/server/formats/__tests__/__snapshots__/fasta-to-beast.test.js.snap
+++ b/server/formats/__tests__/__snapshots__/fasta-to-beast.test.js.snap
@@ -26,7 +26,7 @@ exports[`emydura-short.fasta 1`] = `
 <map name=\\"InverseGamma\\">beast.math.distributions.InverseGamma</map>
 <map name=\\"OneOnX\\">beast.math.distributions.OneOnX</map>
 
-<run id=\\"mcmc\\" spec=\\"MCMC\\" chainLength=\\"1000000\\" storeEvery=\\"5000\\">
+<run id=\\"mcmc\\" spec=\\"MCMC\\" chainLength=\\"10000000\\" storeEvery=\\"5000\\">
 	<state id=\\"state\\" storeEvery=\\"5000\\">
 		<parameter id=\\"popSize\\" name=\\"stateNode\\">1.0</parameter>
 		<tree id=\\"Tree.t:Species\\" name=\\"stateNode\\">

--- a/server/formats/template.xml
+++ b/server/formats/template.xml
@@ -16,7 +16,7 @@
 <map name="InverseGamma">beast.math.distributions.InverseGamma</map>
 <map name="OneOnX">beast.math.distributions.OneOnX</map>
 
-<run id="mcmc" spec="MCMC" chainLength="1000000" storeEvery="5000">
+<run id="mcmc" spec="MCMC" chainLength="10000000" storeEvery="5000">
 	<state id="state" storeEvery="5000">
 		<parameter id="popSize" name="stateNode">1.0</parameter>
 		<tree id="Tree.t:Species" name="stateNode">


### PR DESCRIPTION
Reverts hybsearch/hybsearch#125

With ploidy=0.5 and this set to 1M:

![telegram-cloud-file-1-804723667-179028--2783435575296995246](https://user-images.githubusercontent.com/464441/38646653-6a83e934-3dae-11e8-90fd-e9afa9edbe38.jpg)

With just ploidy=0.5:

![telegram-cloud-file-1-805512819-136088-1555043596462025086](https://user-images.githubusercontent.com/464441/38646590-33937980-3dae-11e8-82a1-247d2d429f1e.jpg)

I think that we should revert this until later, since we're fairly comfortable with the 10M output and that's pretty significantly different when we go to 1M.

---

edit: fixed accidentally attaching the same screenshot twice
edit 2: fixed order of screenshots