### PR TITLE
Shuffle UI blocks around

### DIFF
--- a/electron/graph.js
+++ b/electron/graph.js
@@ -79,7 +79,7 @@ function render(newickData, newickNodes, nmResults) {
 		height: calcHeight,
 		formatLeafNodeLabel: node => {
 			let name = node.name.replace(/_/g, ' ')
-			console.log(node)
+			// console.log(node)
 			return `${name} [${node.ident}] (${node.length})`
 		},
 		nonmonophyly: nmResults

--- a/electron/graph.js
+++ b/electron/graph.js
@@ -2,16 +2,17 @@
 
 const d3 = require('d3')
 d3.phylogram = require('./lib/d3.phylogram')
+const makeTableFromObjectList = require('./lib/html-table')
 
 let nmResults
 let newick
 let newickNodes
 
 function formatEnt(results) {
-	const { nm: nmlist } = results
-	return nmlist
-		.map(pair => pair.map(node => `${node.name} (${node.ident})`).join(' / '))
-		.join('\n')
+	return results.nm.map(pair => {
+		let [left, right] = pair.map(node => `${node.name} (${node.ident})`)
+		return { left, right }
+	})
 }
 
 module.exports.setEntResults = setEntResults
@@ -24,10 +25,15 @@ function setEntResults(results) {
 			: null
 	console.log(non)
 
-	let formattedReslults = formatEnt(nmResults)
-	let resultsEl = document.querySelector('#nonmonophyly-results')
-	resultsEl.innerHTML = `<pre>${formattedReslults}</pre>`
-	document.querySelector('#nm-container').hidden = false
+	if (non) {
+		let formattedReslults = formatEnt(nmResults)
+		document
+			.querySelector('#nonmonophyly-results')
+			.appendChild(makeTableFromObjectList(formattedReslults))
+		document.querySelector('#nm-container').hidden = false
+	} else {
+		console.warn('no nonmonophyly object')
+	}
 
 	// Re-render with the nmResults, assuming newick and newickNodes have already been processed
 	render(newick, newickNodes, nmResults)

--- a/electron/graph.js
+++ b/electron/graph.js
@@ -1,8 +1,8 @@
 'use strict'
 
+const makeTableFromObjectList = require('./lib/html-table')
 const d3 = require('d3')
 d3.phylogram = require('./lib/d3.phylogram')
-const makeTableFromObjectList = require('./lib/html-table')
 
 let nmResults
 let newick

--- a/electron/index.css
+++ b/electron/index.css
@@ -284,7 +284,8 @@ details summary {
 	cursor: pointer;
 }
 
-#jml-container summary > h3 {
+summary > h2,
+summary > h3 {
 	display: inline-block;
 }
 

--- a/electron/index.css
+++ b/electron/index.css
@@ -30,7 +30,7 @@ body {
 }
 
 pre {
-	font-family: Consolas, monospace;
+	font-family: Consolas, Menlo, monospace;
 }
 
 section {
@@ -42,40 +42,29 @@ section {
 	border-bottom: 3px solid var(--blue);
 }
 
-section.loader {
-	transition: height 0.2s ease-in-out, padding 0.2s ease-in-out;
-	position: relative;
-}
-
-section.loader wrapper.loading {
+#loader {
 	display: none;
 }
-section.loader.loading wrapper.loading {
+
+#loader.loading {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(125px, 1fr));
 	grid-row-gap: 0.5rem;
 	grid-column-gap: 0.25rem;
 }
-section.loader.loading wrapper.content {
-	display: none;
-}
 
-.loader {
-	flex: 1;
-}
-
-.loader .checkmark {
+#loader .checkmark {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	color: var(--blue);
 }
 
-.loader .checkmark .label {
+#loader .checkmark .label {
 	text-align: center;
 }
 
-.loader .checkmark .icon {
+#loader .checkmark .icon {
 	border: 2px solid currentColor;
 	height: 30px;
 	width: 30px;
@@ -89,7 +78,7 @@ section.loader.loading wrapper.content {
 	box-sizing: content-box;
 }
 
-.loader .checkmark .icon::before {
+#loader .checkmark .icon::before {
 	content: '';
 	background-color: currentColor;
 	width: 0;
@@ -98,15 +87,15 @@ section.loader.loading wrapper.content {
 	transition: all 0.35s ease-out;
 }
 
-.loader .checkmark.error {
+#loader .checkmark.error {
 	color: var(--red);
 }
 
-.loader .checkmark.complete {
+#loader .checkmark.complete {
 	color: var(--navy);
 }
 
-.loader .checkmark.used-cache {
+#loader .checkmark.used-cache {
 	color: var(--green);
 }
 
@@ -122,18 +111,18 @@ section.loader.loading wrapper.content {
 	}
 }
 
-.loader .checkmark.active .icon::before {
+#loader .checkmark.active .icon::before {
 	animation: pulse 2s infinite;
 	width: 16px;
 	height: 16px;
 }
 
-.loader .checkmark.complete .icon::before {
+#loader .checkmark.complete .icon::before {
 	width: 32px;
 	height: 32px;
 }
 
-.loader .checkmark[data-time]::after {
+#loader .checkmark[data-time]::after {
 	font-size: 0.85em;
 	content: attr(data-time);
 }
@@ -198,11 +187,6 @@ button:active {
 input[type='text'],
 input[type='url'] {
 	padding: 10px 15px;
-}
-
-section wrapper {
-	width: 100%;
-	display: inline-block;
 }
 
 .right-aligned {

--- a/electron/index.css
+++ b/electron/index.css
@@ -280,10 +280,6 @@ section button {
 	overflow-x: scroll;
 }
 
-#jml-container table {
-	width: 100%;
-}
-
 details summary {
 	cursor: pointer;
 }
@@ -292,10 +288,14 @@ details summary {
 	display: inline-block;
 }
 
-#jml-container table th {
+.results-table {
+	width: 100%;
+}
+
+.results-table th {
 	text-align: left;
 }
 
-#jml-container table .highlight {
+.results-table .highlight {
 	background-color: lightyellow;
 }

--- a/electron/index.html
+++ b/electron/index.html
@@ -60,8 +60,7 @@
 
 		<section hidden id="omitted-container">
 			<h2>Omitted Sequences</h2>
-			<p>The following sequences were omitted because they were more than 20% different to a majority of the sequences. </p>
-			<div id="omitted-results"></div>
+			<p>The following sequences were omitted because they were more than 20% different when compared with a majority of the sequences.</p>
 		</section>
 
 		<section hidden id="nm-container">

--- a/electron/index.html
+++ b/electron/index.html
@@ -49,7 +49,7 @@
 
 		<section>
 			<details>
-				<summary><h2 style="display: inline">Use a Newick Tree</h2></summary>
+				<summary><h2>Use a Newick Tree</h2></summary>
 				<textarea id="tree-box"></textarea>
 				<wrapper class="right-aligned">
 					<input type="submit" value="newick" id="tree-box-submit">

--- a/electron/index.html
+++ b/electron/index.html
@@ -10,32 +10,41 @@
 			<button id="reload">Restart ⟳</button>
 		</div>
 
-		<section class="loader">
-			<wrapper class="content">
-				<h2>Genbank/Fasta</h2>
-				<input type="file" id="load-file" accept=".gb,.genbank,.fasta">
-				<select id="pick-file">
-					<option>No file chosen</option>
-				</select>
-				<br/><br/>
-				<span id="server-status" class="down"></span>
-				<label>
-					Server:
-					<input type="url" id="server-url" value="ws://localhost:8080/" placeholder="ws://server:port/">
-				</label>
-				<button id="use-thing3" data-url="ws://thing3.cs.stolaf.edu:80/">Use Thing3</button>
-				<button id="use-localhost" data-url="ws://localhost:8080/">Use localhost</button>
-				<br/><br/>
-				<label for="pick-pipeline">Pipeline:</label>
-				<select id="pick-pipeline">
-					<option>No pipelines present</option>
-				</select>
-				<br/><br/>
-				<button id="start">Run Hybsearch</button>
-			</wrapper>
-			<wrapper class="loading">
-			</wrapper>
+		<section id="file-input">
+			<h2>Genbank/Fasta</h2>
+			<input type="file" id="load-file" accept=".gb,.genbank,.fasta">
+			<select id="pick-file">
+				<option>No file chosen</option>
+			</select>
+			<br/><br/>
+			<span id="server-status" class="down"></span>
+			<label>
+				Server:
+				<input type="url" id="server-url" value="ws://localhost:8080/" placeholder="ws://server:port/">
+			</label>
+			<button id="use-thing3" data-url="ws://thing3.cs.stolaf.edu:80/">Use Thing3</button>
+			<button id="use-localhost" data-url="ws://localhost:8080/">Use localhost</button>
+			<br/><br/>
+			<label for="pick-pipeline">Pipeline:</label>
+			<select id="pick-pipeline">
+				<option>No pipelines present</option>
+			</select>
+			<br/><br/>
+			<button id="start">Run Hybsearch</button>
 		</section>
+
+		<section id="newick-input">
+			<details>
+				<summary><h2>Use a Newick Tree</h2></summary>
+				<textarea id="tree-box"></textarea>
+				<wrapper class="right-aligned">
+					<input type="submit" value="newick" id="tree-box-submit">
+					<input type="submit" value="json" id="json-tree-box-submit">
+				</wrapper>
+			</details>
+		</section>
+
+		<section hidden id="loader"></section>
 
 		<section hidden id="error-container">
 			<h2>Errors</h2>
@@ -45,17 +54,6 @@
 		<section hidden id="phylogram">
 			<h2>Phylogram</h2>
 			<div id="phylogram"></div>
-		</section>
-
-		<section>
-			<details>
-				<summary><h2>Use a Newick Tree</h2></summary>
-				<textarea id="tree-box"></textarea>
-				<wrapper class="right-aligned">
-					<input type="submit" value="newick" id="tree-box-submit">
-					<input type="submit" value="json" id="json-tree-box-submit">
-				</wrapper>
-			</details>
 		</section>
 
 		<section hidden id="omitted-container">

--- a/electron/index.html
+++ b/electron/index.html
@@ -37,17 +37,6 @@
 			</wrapper>
 		</section>
 
-		<section hidden id="nm-container">
-			<h2>Nonmonophyly</h2>
-			<div id="nonmonophyly-results"></div>
-		</section>
-
-		<section hidden id="omitted-container">
-			<h2>Omitted Sequences</h2>
-			<p>The following sequences were omitted because they were more than 20% different to a majority of the sequences. </p>
-			<div id="omitted-results"></div>
-		</section>
-
 		<section hidden id="error-container">
 			<h2>Errors</h2>
 			<pre id="error-message"></pre>
@@ -67,6 +56,17 @@
 					<input type="submit" value="json" id="json-tree-box-submit">
 				</wrapper>
 			</details>
+		</section>
+
+		<section hidden id="omitted-container">
+			<h2>Omitted Sequences</h2>
+			<p>The following sequences were omitted because they were more than 20% different to a majority of the sequences. </p>
+			<div id="omitted-results"></div>
+		</section>
+
+		<section hidden id="nm-container">
+			<h2>Nonmonophyly</h2>
+			<div id="nonmonophyly-results"></div>
 		</section>
 
 		<section hidden id="jml-container">

--- a/electron/lib/html-table.js
+++ b/electron/lib/html-table.js
@@ -4,6 +4,7 @@ const toPairs = require('lodash/toPairs')
 module.exports = makeTableFromObjectList
 function makeTableFromObjectList(data) {
 	let table = document.createElement('table')
+	table.classList.add('results-table')
 
 	let thead = document.createElement('thead')
 	let tr = document.createElement('tr')

--- a/electron/lib/html-table.js
+++ b/electron/lib/html-table.js
@@ -1,0 +1,51 @@
+'use strict'
+const toPairs = require('lodash/toPairs')
+
+module.exports = makeTableFromObjectList
+function makeTableFromObjectList(data) {
+	let table = document.createElement('table')
+
+	let thead = document.createElement('thead')
+	let tr = document.createElement('tr')
+
+	let first = data[0]
+	if (!first) {
+		return table
+	}
+
+	let keys = Object.keys(first).filter(key => !key.startsWith('__'))
+
+	for (let key of keys) {
+		let th = document.createElement('th')
+		th.innerHTML = key
+		tr.appendChild(th)
+	}
+
+	thead.appendChild(tr)
+	table.appendChild(thead)
+
+	let tbody = document.createElement('tbody')
+	for (let distribution of data) {
+		let tr = document.createElement('tr')
+
+		if (distribution.__highlight) {
+			tr.classList.add('highlight')
+		}
+
+		let values = toPairs(distribution)
+			.filter(([key]) => !key.startsWith('__'))
+			.map(([_, value]) => value)
+
+		for (let value of values) {
+			let td = document.createElement('td')
+			td.innerHTML = value
+			tr.appendChild(td)
+		}
+
+		tbody.appendChild(tr)
+	}
+
+	table.appendChild(tbody)
+
+	return table
+}

--- a/electron/run.js
+++ b/electron/run.js
@@ -17,7 +17,13 @@ function run() {
 	const data = fs.readFileSync(filepath, 'utf-8')
 
 	// start the loading bar
-	document.querySelector('section.loader').classList.add('loading')
+	let loader = document.querySelector('#loader')
+	loader.classList.add('loading')
+	loader.hidden = false
+
+	// hide the input boxes
+	document.querySelector('#file-input').hidden = true
+	document.querySelector('#newick-input').hidden = true
 
 	// get the chosen pipeline name
 	let pipeline = document.querySelector('#pick-pipeline').value

--- a/electron/run.js
+++ b/electron/run.js
@@ -60,16 +60,15 @@ function onData(phase, data) {
 		load(data)
 	} else if (phase === 'pruned-identifiers') {
 		let container = document.querySelector('#omitted-container')
-		let results = document.querySelector('#omitted-results')
 
 		let formattedNames = data.map(node => {
 			let ident = node.ident ? ` [${node.ident}]` : ''
-			return `${node.name}${ident} (${node.length})`
+			return { node: `${node.name}${ident} (${node.length})` }
 		})
 
 		if (formattedNames.length > 0) {
-			results.innerHTML = `<pre>${formattedNames.join('\n')}</pre>`
 			container.hidden = false
+			container.appendChild(makeTableFromObjectList(formattedNames))
 		}
 	} else if (phase === 'jml-output') {
 		let container = document.querySelector('#jml-container')

--- a/electron/run.js
+++ b/electron/run.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const { load, setEntResults } = require('./graph')
+const makeTableFromObjectList = require('./lib/html-table')
 const prettyMs = require('pretty-ms')
 const fs = require('fs')
-const toPairs = require('lodash/toPairs')
 
 function run() {
 	// get the file
@@ -51,54 +51,6 @@ function submitJob({ socket = global.socket, pipeline, filepath, data }) {
 	})
 }
 
-function makeTableFromObject(data) {
-	let table = document.createElement('table')
-
-	let thead = document.createElement('thead')
-	let tr = document.createElement('tr')
-
-	let first = data[0]
-	if (!first) {
-		return table
-	}
-
-	let keys = Object.keys(first).filter(key => !key.startsWith('__'))
-
-	for (let key of keys) {
-		let th = document.createElement('th')
-		th.innerHTML = key
-		tr.appendChild(th)
-	}
-
-	thead.appendChild(tr)
-	table.appendChild(thead)
-
-	let tbody = document.createElement('tbody')
-	for (let distribution of data) {
-		let tr = document.createElement('tr')
-
-		if (distribution.__highlight) {
-			tr.classList.add('highlight')
-		}
-
-		let values = toPairs(distribution)
-			.filter(([key]) => !key.startsWith('__'))
-			.map(([_, value]) => value)
-
-		for (let value of values) {
-			let td = document.createElement('td')
-			td.innerHTML = value
-			tr.appendChild(td)
-		}
-
-		tbody.appendChild(tr)
-	}
-
-	table.appendChild(tbody)
-
-	return table
-}
-
 function onData(phase, data) {
 	console.info([phase, data])
 	if (phase.startsWith('newick-json:')) {
@@ -125,11 +77,11 @@ function onData(phase, data) {
 
 		document
 			.querySelector('#distributions')
-			.appendChild(makeTableFromObject(data.distributions))
+			.appendChild(makeTableFromObjectList(data.distributions))
 
 		document
 			.querySelector('#probabilities')
-			.appendChild(makeTableFromObject(data.probabilities))
+			.appendChild(makeTableFromObjectList(data.probabilities))
 
 		data.results = data.results.map(item => {
 			if (item.Probability < 0.05) {
@@ -139,7 +91,7 @@ function onData(phase, data) {
 		})
 		document
 			.querySelector('#results')
-			.appendChild(makeTableFromObject(data.results))
+			.appendChild(makeTableFromObjectList(data.results))
 	} else if (phase === 'nonmonophyletic-sequences') {
 		setEntResults(data)
 	} else {

--- a/electron/run.js
+++ b/electron/run.js
@@ -62,9 +62,11 @@ function makeTableFromObject(data) {
 		return table
 	}
 
-	for (let comparison of Object.keys(first)) {
+	let keys = Object.keys(first).filter(key => !key.startsWith('__'))
+
+	for (let key of keys) {
 		let th = document.createElement('th')
-		th.innerHTML = comparison
+		th.innerHTML = key
 		tr.appendChild(th)
 	}
 

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -86,7 +86,7 @@ function connectionIsUp() {
 					.reduce((acc, item) => [...acc, ...item], [])
 			)
 
-			let el = document.querySelector('wrapper.loading')
+			let el = document.querySelector('#loader')
 			el.innerHTML = steps
 				.map(
 					stage =>


### PR DESCRIPTION
- Moves the nonmonophyly block below the graph, and turns it into a table (closes #114)
- Hides the Newick Tree input block while the pipeline is running (closes #113)
- Turns the "omitted sequences" block into a single-column table (just so it matches the others; the single column is called "node")
- Fixes a bug where the JML results table would grow a `__highlight` column (which is not useful)
- Disables the logging of every leaf graph node to the electron console
- Some minor code cleanup

### Newick before/after

before | after
--- | ---
![screen shot 2018-04-11 at 6 15 30 pm](https://user-images.githubusercontent.com/464441/38647917-55c381e8-3db4-11e8-96f1-f738e34a574f.png) | ![screen shot 2018-04-11 at 6 14 30 pm 1](https://user-images.githubusercontent.com/464441/38647896-37a9da40-3db4-11e8-825e-5730771ac283.png)
