### PR TITLE
Show the current app version in the titlebar

### DIFF
--- a/electron/__tests__/app.test.js
+++ b/electron/__tests__/app.test.js
@@ -22,5 +22,5 @@ test('verify a visible window is opened with a title', async () => {
 	expect(await app.browserWindow.isVisible()).toBe(true)
 
 	// Verify the window's title
-	expect(await app.client.getTitle()).toBe('Hybsearch')
+	expect(await app.client.getTitle()).toMatch(/^Hybsearch/)
 })

--- a/electron/index.html
+++ b/electron/index.html
@@ -2,7 +2,6 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
-		<title>Hybsearch</title>
 		<link rel="stylesheet" href="./index.css">
 	</head>
 	<body>

--- a/electron/main.js
+++ b/electron/main.js
@@ -4,6 +4,7 @@ const {
 	app, // Module to control application life.
 	BrowserWindow, // Module to create native browser window.
 } = require('electron')
+const { version } = require('./package.json')
 
 // catch unhandled promise rejections
 require('electron-unhandled')()
@@ -37,6 +38,7 @@ function createWindow() {
 		width: 900,
 		height: 775,
 		backgroundColor: '#F7F7F7',
+		title: `HybSearch (v${version})`,
 	})
 
 	// and load the index.html of the app.


### PR DESCRIPTION
Closes #134 

On dev, it shows `HybSearch (v0.0.0)`; on a tagged build that you download, it'll show `HybSearch (v4.0.0-beta.17)` or whatever.

<img width="900" alt="image" src="https://user-images.githubusercontent.com/464441/38683307-bc26f6bc-3e32-11e8-8b36-6f6e75957496.png">
