### PR TITLE
Add pipeline caches to the docker-compose file

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -6,9 +6,21 @@ services:
     restart: unless-stopped
     ports:
       - 0.0.0.0:80:8080
+    volumes:
+      - type: "volume"
+        source: "hs--pipeline-cache"
+        target: "/tmp/hybsearch"
 
   hs-head:
     image: docker.io/hybsearch/hybsearch:HEAD
     restart: unless-stopped
     ports:
       - 0.0.0.0:81:8080
+    volumes:
+      - type: "volume"
+        source: "hs-head--pipeline-cache"
+        target: "/tmp/hybsearch"
+
+volumes:
+  hs--pipeline-cache:
+  hs-head--pipeline-cache:


### PR DESCRIPTION
This will more explicitly define what we want, which is for pipeline caches to be persistent across runs.

I do this by adding two volumes.  Note that these files will not be accessible on the docker host side, as they shouldn't need to be.  Instead, we just just use Docker volumes.  If you need to get data out of this container, it's possible to do `--volumes-from` with a busybox container and then do a bridge mount.  But we don't need that.