### PR TITLE
Add REST endpoints to allow us to not use websockets for everything

### DIFF
--- a/electron/ui.js
+++ b/electron/ui.js
@@ -9,6 +9,8 @@ const { attachListeners } = require('./run')
 
 attachListeners()
 
+const fetchJson = (...args) => fetch(...args).then(r => r.json())
+
 global.socket = new WebSocket(document.querySelector('#server-url').value)
 initWebsocket()
 
@@ -46,58 +48,27 @@ document.querySelector('#server-url').addEventListener('change', ev => {
 	updateWebSocket(ev.currentTarget.value)
 })
 
-const getSteps = pipeline =>
-	global.socket.send(
-		JSON.stringify({
-			type: 'pipeline-steps',
-			pipeline: pipeline,
-		})
-	)
+const getSteps = (baseUrl, pipeline) =>
+	fetchJson(`${baseUrl}pipeline/${pipeline}`)
 
-function connectionIsUp() {
+async function connectionIsUp() {
 	document.querySelector('#server-status').classList.remove('down')
 	document.querySelector('#server-status').classList.add('up')
 
-	global.socket.send(JSON.stringify({ type: 'pipeline-list' }), err => {
-		if (err) {
-			console.error('server error', err)
-			window.alert('server error:', err.message)
-		}
-	})
+	let baseUrl = global.socket.url.replace('ws:', 'http:')
 
-	global.socket.addEventListener('message', ({ data }) => {
-		data = JSON.parse(data)
-		if (data.type === 'pipeline-list') {
-			let pipelines = JSON.parse(data.payload)
+	let [uptime, pipelines, files] = await Promise.all([
+		fetchJson(baseUrl + 'uptime').then(r => r.uptime),
+		fetchJson(baseUrl + 'pipelines').then(r => r.pipelines),
+		fetchJson(baseUrl + 'files').then(r => r.files),
+	])
 
-			let el = document.querySelector('#pick-pipeline')
-			el.innerHTML = pipelines
-				.map(name => `<option value="${name}">${name}</option>`)
-				.join('')
+	console.log('uptime', uptime)
+	console.log('pipelines', pipelines)
+	console.log('server files', files)
 
-			getSteps(pipelines[0])
-			el.addEventListener('change', ev => getSteps(ev.currentTarget.value))
-		} else if (data.type === 'pipeline-steps') {
-			let payload = JSON.parse(data.payload)
-
-			let steps = uniq(
-				payload
-					.map(segment => [...segment.input, ...segment.output])
-					.reduce((acc, item) => [...acc, ...item], [])
-			)
-
-			let el = document.querySelector('#loader')
-			el.innerHTML = steps
-				.map(
-					stage =>
-						`<div class="checkmark" data-loader-name="${stage}">
-							<div class="icon"></div>
-							<div class="label">${stage}</div>
-						</div>`
-				)
-				.join('')
-		}
-	})
+	populatePipelinePicker(pipelines, baseUrl)
+	populateFilePicker(files, baseUrl)
 
 	global.socket.addEventListener('disconnect', (...args) =>
 		console.log('disconnect', ...args)
@@ -116,37 +87,72 @@ function connectionRefused() {
 	// event listeners when the socket changes
 }
 
-const files = getFiles()
-const groupedFiles = groupBy(files, ({ filename }) => {
-	if (/\.aln/.test(filename)) {
-		return 'aligned'
-	}
+function populateFilePicker(files) {
+	files = files.length ? files : getFiles()
 
-	if (filename.endsWith('.fasta')) {
-		return 'fasta'
-	}
+	const groupedFiles = groupBy(files, ({ filename }) => {
+		if (/\.aln/.test(filename)) {
+			return 'aligned'
+		}
 
-	if (filename.endsWith('.gb')) {
-		return 'genbank'
-	}
+		if (filename.endsWith('.fasta')) {
+			return 'fasta'
+		}
 
-	return filename.split('.')[filename.split('.').length - 1]
-})
+		if (filename.endsWith('.gb')) {
+			return 'genbank'
+		}
 
-const optgroups = mapValues(groupedFiles, group =>
-	group.map(({ filename, filepath }) => {
-		let opt = document.createElement('option')
-		opt.value = filepath
-		opt.textContent = filename
-		return opt
+		return filename.split('.')[filename.split('.').length - 1]
 	})
-)
 
-const picker = document.querySelector('#pick-file')
+	const optgroups = mapValues(groupedFiles, group =>
+		group.map(({ filename, filepath }) => {
+			let opt = document.createElement('option')
+			opt.value = filepath
+			opt.textContent = filename
+			return opt
+		})
+	)
 
-for (let [type, options] of toPairs(optgroups)) {
-	let group = document.createElement('optgroup')
-	group.label = type
-	options.forEach(opt => group.appendChild(opt))
-	picker.appendChild(group)
+	const picker = document.querySelector('#pick-file')
+
+	for (let [type, options] of toPairs(optgroups)) {
+		let group = document.createElement('optgroup')
+		group.label = type
+		options.forEach(opt => group.appendChild(opt))
+		picker.appendChild(group)
+	}
+}
+
+function populatePipelinePicker(pipelines, baseUrl) {
+	let pipelinesPicker = document.querySelector('#pick-pipeline')
+	pipelinesPicker.innerHTML = pipelines
+		.map(name => `<option value="${name}">${name}</option>`)
+		.join('')
+
+	getSteps(baseUrl, pipelines[0]).then(handleNewSteps)
+
+	pipelinesPicker.addEventListener('change', ev =>
+		getSteps(baseUrl, ev.currentTarget.value).then(handleNewSteps)
+	)
+}
+
+const handleNewSteps = payload => {
+	let steps = uniq(
+		payload.steps
+			.map(segment => [...segment.input, ...segment.output])
+			.reduce((acc, item) => [...acc, ...item], [])
+	)
+
+	let el = document.querySelector('#loader')
+	el.innerHTML = steps
+		.map(
+			stage =>
+				`<div class="checkmark" data-loader-name="${stage}">
+					<div class="icon"></div>
+					<div class="label">${stage}</div>
+				</div>`
+		)
+		.join('')
 }

--- a/server/lib/get-files.js
+++ b/server/lib/get-files.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const DIR = process.env.DOCKER
+	? path.join(__dirname, '..', 'data') // '/data'
+	: path.join(__dirname, '..', '..', 'data')
+
+async function getFiles() {
+	return fs
+		.readdirSync(DIR)
+		.filter(file => /\.(fasta|gb)$/.test(file))
+		.map(f => ({ filename: f, filepath: f }))
+}
+
+async function loadFile(filename) {
+	return fs.readFileSync(path.join(DIR, filename), 'utf-8')
+}
+
+module.exports = getFiles
+module.exports.loadFile = loadFile

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4,10 +4,24 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "aproba": {
       "version": "1.2.0",
@@ -62,11 +76,21 @@
         "prebuild-install": "2.5.1"
       }
     },
+    "bytes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
+      "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
+    },
     "chownr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
       "optional": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -83,10 +107,37 @@
       "resolved": "https://registry.npmjs.org/comma-separated-values/-/comma-separated-values-3.6.4.tgz",
       "integrity": "sha1-wwnscCT3S3rhkiM3IFQkJhfjW9I="
     },
+    "compressible": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+      "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookies": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
+      "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
+      "requires": {
+        "depd": "1.1.2",
+        "keygrip": "1.0.2"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -118,6 +169,14 @@
         "array-find-index": "1.0.2"
       }
     },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -132,6 +191,11 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
@@ -141,14 +205,28 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "optional": true
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "optional": true
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -157,6 +235,21 @@
       "requires": {
         "once": "1.4.0"
       }
+    },
+    "error-inject": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
+      "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "execa": {
       "version": "0.10.0",
@@ -177,6 +270,11 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
       "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ==",
       "optional": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "gauge": {
       "version": "2.7.4",
@@ -210,11 +308,44 @@
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
       "optional": true
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "optional": true
+    },
+    "http-assert": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",
+      "integrity": "sha1-oxpc+IyHPsu1eWkH1NbxMujAHko=",
+      "requires": {
+        "deep-equal": "1.0.1",
+        "http-errors": "1.6.3"
+      }
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.5.0"
+      }
+    },
+    "humanize-number": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz",
+      "integrity": "sha1-EcCvakcWQ2M1iFiASPF5lUFInBg="
     },
     "inherits": {
       "version": "2.0.3",
@@ -235,6 +366,11 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -249,6 +385,140 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha1-rTKXxVcGneqLz+ek+kkbdcXd65E="
+    },
+    "koa": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.5.0.tgz",
+      "integrity": "sha512-UkrbMW2mRNfoW/4I20knJEjtPAWCV3Iw6f4XdnPWjHsCN8iTeSh0eSutrYdL0fGF/G9on2eQ30EEQif0MarGJA==",
+      "requires": {
+        "accepts": "1.3.5",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookies": "0.7.1",
+        "debug": "3.1.0",
+        "delegates": "1.0.0",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "error-inject": "1.0.0",
+        "escape-html": "1.0.3",
+        "fresh": "0.5.2",
+        "http-assert": "1.3.0",
+        "http-errors": "1.6.3",
+        "is-generator-function": "1.0.7",
+        "koa-compose": "4.0.0",
+        "koa-convert": "1.2.0",
+        "koa-is-json": "1.0.0",
+        "mime-types": "2.1.18",
+        "on-finished": "2.3.0",
+        "only": "0.0.2",
+        "parseurl": "1.3.2",
+        "statuses": "1.5.0",
+        "type-is": "1.6.16",
+        "vary": "1.1.2"
+      }
+    },
+    "koa-compose": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.0.0.tgz",
+      "integrity": "sha1-KAClE9nDYe8NY4UrA45Pby1adzw="
+    },
+    "koa-compress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-2.0.0.tgz",
+      "integrity": "sha1-e36ykhuEd0a14SK6n1zYpnHo6jo=",
+      "requires": {
+        "bytes": "2.5.0",
+        "compressible": "2.0.13",
+        "koa-is-json": "1.0.0",
+        "statuses": "1.5.0"
+      }
+    },
+    "koa-convert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
+      "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
+      "requires": {
+        "co": "4.6.0",
+        "koa-compose": "3.2.1"
+      },
+      "dependencies": {
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "1.3.0"
+          }
+        }
+      }
+    },
+    "koa-is-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
+      "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ="
+    },
+    "koa-logger": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/koa-logger/-/koa-logger-3.2.0.tgz",
+      "integrity": "sha512-IQhaKkWvvbjnmMIcHSK/cH2RCYt64jOxliazVF1wZdXH0KbmM5VHgn1v3r9a9mqInDPDMR+JoiErSFc83epLaQ==",
+      "requires": {
+        "bytes": "2.5.0",
+        "chalk": "1.1.3",
+        "humanize-number": "0.0.2",
+        "passthrough-counter": "1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
+    "koa-router": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-7.4.0.tgz",
+      "integrity": "sha512-IWhaDXeAnfDBEpWS6hkGdZ1ablgr6Q6pGdXCyK38RbzuH4LkUOpPqPw+3f8l8aTDrQmBQ7xJc0bs2yV4dzcO+g==",
+      "requires": {
+        "debug": "3.1.0",
+        "http-errors": "1.6.3",
+        "koa-compose": "3.2.1",
+        "methods": "1.1.2",
+        "path-to-regexp": "1.7.0",
+        "urijs": "1.19.1"
+      },
+      "dependencies": {
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "1.3.0"
+          }
+        }
+      }
     },
     "lodash": {
       "version": "4.17.5",
@@ -270,6 +540,29 @@
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "requires": {
         "pify": "3.0.0"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
       }
     },
     "mimic-response": {
@@ -298,11 +591,21 @@
         }
       }
     },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
       "optional": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nice-try": {
       "version": "1.0.4",
@@ -355,6 +658,14 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "optional": true
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -362,6 +673,11 @@
       "requires": {
         "wrappy": "1.0.2"
       }
+    },
+    "only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -374,10 +690,35 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "passthrough-counter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-1.0.0.tgz",
+      "integrity": "sha1-GWfZ5m2lcrXAI8eH2xEqOHqxZvo="
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
     },
     "pify": {
       "version": "3.0.0",
@@ -469,6 +810,11 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "optional": true
     },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -503,6 +849,11 @@
         "once": "1.4.0",
         "simple-concat": "1.0.0"
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-width": {
       "version": "1.0.2",
@@ -600,6 +951,15 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
+      }
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -607,6 +967,11 @@
       "requires": {
         "crypto-random-string": "1.0.0"
       }
+    },
+    "urijs": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
     },
     "utf-8-validate": {
       "version": "4.0.1",
@@ -623,6 +988,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "which": {
       "version": "1.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "hyb-seq-gen": "./wrappers/seq-gen/hyb-seq-gen"
   },
   "scripts": {
-    "start": "./server.js",
+    "start": "env NODE_ENV=production ./server.js",
     "lint": "cd .. && npm run lint",
     "prettify": "cd .. && npm run prettify",
     "pretty-check": "cd .. && npm run pretty-check",
@@ -32,6 +32,10 @@
     "dedent": "^0.7.0",
     "execa": "^0.10.0",
     "get-stdin": "^6.0.0",
+    "koa": "^2.5.0",
+    "koa-compress": "^2.0.0",
+    "koa-logger": "^3.2.0",
+    "koa-router": "^7.4.0",
     "lodash": "^4.17.5",
     "loud-rejection": "^1.6.0",
     "make-dir": "^1.2.0",

--- a/server/pipeline/worker.js
+++ b/server/pipeline/worker.js
@@ -52,7 +52,7 @@ process.on('disconnect', () => {
 ///// pipeline
 /////
 
-async function main({ pipeline: pipelineName, filepath, data, type }) {
+async function main({ pipeline: pipelineName, filepath, data }) {
 	let start = now()
 
 	try {

--- a/server/pipeline/worker.js
+++ b/server/pipeline/worker.js
@@ -5,6 +5,7 @@ const serializeError = require('serialize-error')
 const Cache = require('./cache')
 const zip = require('lodash/zip')
 const PIPELINES = require('./pipelines')
+const { loadFile } = require('../lib/get-files')
 
 /////
 ///// helpers
@@ -54,21 +55,11 @@ process.on('disconnect', () => {
 async function main({ pipeline: pipelineName, filepath, data, type }) {
 	let start = now()
 
-	if (type === 'pipeline-list') {
-		send({
-			type: 'pipeline-list',
-			payload: JSON.stringify(Object.keys(PIPELINES)),
-		})
-		return
-	} else if (type === 'pipeline-steps') {
-		send({
-			type: 'pipeline-steps',
-			payload: JSON.stringify(PIPELINES[pipelineName]),
-		})
-		return
-	}
-
 	try {
+		if (!data) {
+			data = await loadFile(filepath)
+		}
+
 		let cache = new Cache({ filepath, contents: data })
 
 		let pipeline = PIPELINES[pipelineName]

--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,9 @@ const Koa = require('koa')
 const Router = require('koa-router')
 const compress = require('koa-compress')
 const logger = require('koa-logger')
+const getFiles = require('./lib/get-files')
+const { loadFile } = getFiles
+
 const PORT = 8080
 const app = new Koa()
 const server = new http.createServer(app.callback())
@@ -38,6 +41,13 @@ router.get('/pipeline/:name', ctx => {
 	}
 })
 
+router.get('/files', async ctx => {
+	ctx.body = { files: await getFiles() }
+})
+
+router.get('/file/:name', async ctx => {
+	ctx.body = { content: await loadFile(ctx.params.name) }
+})
 
 router.get('/uptime', ctx => {
 	ctx.body = { uptime: Date.now() - STARTED }

--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,7 @@ const PORT = 8080
 const server = new http.createServer(app.callback())
 const wss = new WebSocket.Server({
 	server,
+	perMessageDeflate: {},
 })
 
 

--- a/server/server.js
+++ b/server/server.js
@@ -4,22 +4,16 @@
 const WebSocket = require('ws')
 const childProcess = require('child_process')
 const path = require('path')
+const http = require('http')
+const PORT = 8080
+const server = new http.createServer(app.callback())
+const wss = new WebSocket.Server({
+	server,
+})
 
-const [port = 8080] = process.argv.slice(2)
-const numericPort = parseInt(port)
 
-if (port === '-h' || port === '--help') {
-	console.error('usage: server.js [PORT=8080]')
-	process.exit(1)
-}
 
-if (Number.isNaN(numericPort)) {
-	console.error('usage: server.js [PORT=8080]')
-	console.error('error: given port was not a number')
-	process.exit(1)
-}
 
-const wss = new WebSocket.Server({ port: numericPort })
 const workerPath = path.join(__dirname, 'pipeline', 'worker.js')
 
 function trimMessage(message) {
@@ -74,4 +68,5 @@ wss.on('connection', ws => {
 	})
 })
 
-console.log(`listening on localhost:${port}`)
+server.listen(PORT)
+console.log(`listening on localhost:${PORT}`)

--- a/server/server.js
+++ b/server/server.js
@@ -5,15 +5,29 @@ const WebSocket = require('ws')
 const childProcess = require('child_process')
 const path = require('path')
 const http = require('http')
+const Koa = require('koa')
+const Router = require('koa-router')
+const compress = require('koa-compress')
+const logger = require('koa-logger')
 const PORT = 8080
+const app = new Koa()
 const server = new http.createServer(app.callback())
 const wss = new WebSocket.Server({
 	server,
 	perMessageDeflate: {},
 })
 
+const router = new Router()
+
+router.get('/', ctx => {
+	ctx.body = 'hello, world!'
+})
 
 
+app.use(logger())
+app.use(compress())
+app.use(router.routes())
+app.use(router.allowedMethods())
 
 const workerPath = path.join(__dirname, 'pipeline', 'worker.js')
 

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict'
 
+const STARTED = Date.now()
 const WebSocket = require('ws')
 const childProcess = require('child_process')
 const path = require('path')
@@ -23,6 +24,10 @@ router.get('/', ctx => {
 	ctx.body = 'hello, world!'
 })
 
+
+router.get('/uptime', ctx => {
+	ctx.body = { uptime: Date.now() - STARTED }
+})
 
 app.use(logger())
 app.use(compress())

--- a/server/server.js
+++ b/server/server.js
@@ -18,10 +18,24 @@ const wss = new WebSocket.Server({
 	perMessageDeflate: {},
 })
 
+const PIPELINES = require('./pipeline/pipelines')
 const router = new Router()
 
 router.get('/', ctx => {
 	ctx.body = 'hello, world!'
+})
+
+router.get('/pipelines', ctx => {
+	ctx.body = { pipelines: Object.keys(PIPELINES) }
+})
+
+router.get('/pipeline/:name', ctx => {
+	let pipe = PIPELINES[ctx.params.name]
+	if (pipe) {
+		ctx.body = { steps: pipe }
+	} else {
+		ctx.throw(404, { error: 'pipeline not found' })
+	}
 })
 
 

--- a/server/server.js
+++ b/server/server.js
@@ -15,7 +15,7 @@ const { loadFile } = getFiles
 
 const PORT = 8080
 const app = new Koa()
-const server = new http.createServer(app.callback())
+const server = http.createServer(app.callback())
 const wss = new WebSocket.Server({
 	server,
 	perMessageDeflate: {},


### PR DESCRIPTION
(@rye has been bugging me to do this for a while)

This lets the non-live bits of the app, like getting the list of pipelines, happen over a normal HTTP connection, instead of sending a message and waiting for a keyed response.

```js
socket.on('message', msg => {
    let payload = JSON.parse(msg)
    if (payload.type === 'get-pipelines') {
        doThings(payload.pipelines)
    }
})
socket.send('get-pipelines')
```

can become

```js
fetchJson(`${server}/pipelines`).then(doThings)
```

It should make for a much cleaner separation between the pipelines (which will stay on sockets) and the rest of the app.

@OmarShehata / @mollysrour – this probably doesn't change much for you, since you have been mainly working with pipeline data.

<details><summary>EDIT: removed this part from the PR</summary>

This also moves our stored file list onto the server, except that I'm having some issues with that.

## TODO
- I don't know how to get the list of files onto the server. The /data folder isn't in the docker build context, and I don't think Kris wants to pull them separately. Thoughts?
</details>