### PR TITLE
Remove the pip upgrade step from Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir /hybsearch
 WORKDIR /hybsearch
 
 ADD ["requirements.txt", "./"]
-RUN pip install --upgrade pip && pip install -r requirements.txt
+RUN pip install -r requirements.txt
 
 ADD ["package.json", "package-lock.json", "./"]
 RUN npm install

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir /hybsearch
 WORKDIR /hybsearch
 
 ADD ["requirements.txt", "./"]
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 ADD ["package.json", "package-lock.json", "./"]
 RUN npm install


### PR DESCRIPTION
We had it in there so that the wheel building step would pass, but since we don't use wheels to distribute our packages we don't care if the wheels build or not.

Wheels are a binary distribution format for Python packages, and I have yet to figure out how to ask Python to not generate them. Since we don't need to distribute the python package that we're building, we can ignore the fact that the wheels fail to build.

If the build failures mattered, `pip install` would exit with a non-0 status code, so this shouldn't affect our future stability.