### PR TITLE
Declare 3.2 as the version on docker-compose.yml

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: '3.2'
 services:
   hs:
     image: docker.io/hybsearch/hybsearch:latest


### PR DESCRIPTION
This enables the extended volumes syntax.  And prevents clients from using the stupid old syntax.