### PR TITLE
Add run step for mkdir data/ in the build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update \
 ENV DOCKER=1
 
 RUN mkdir /hybsearch
+RUN mkdir /hybsearch/data
 WORKDIR /hybsearch
 
 ADD ["requirements.txt", "./"]


### PR DESCRIPTION
This should be harmless one way or the other, and immediately closes #145.

Older clients get a different error due to complete protocol mismatch, as we completely broke the old way of talking to the server in favor of a much better way.