### PR TITLE
Run JML on the entire aligned FASTA dataset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybsearch/hybsearch",
-  "version": "4.0.0-beta.21",
+  "version": "4.0.0-beta.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybsearch/hybsearch",
   "private": true,
-  "version": "4.0.0-beta.21",
+  "version": "4.0.0-beta.22",
   "description": "Find nonmonophyly in genetic sequences",
   "repository": "hybsearch/hybsearch",
   "homepage": "https://hybsearch.github.io/",

--- a/server/ent/__tests__/more-ent.test.js
+++ b/server/ent/__tests__/more-ent.test.js
@@ -37,10 +37,8 @@ for (const file of files) {
 		let nonmonoInfo = removeCircularLinks(
 			ent.strictSearch(JSON.parse(serializedNewick), alignedFasta)
 		)
-		console.log(nonmonoInfo.nm)
 
 		let monophyleticFasta = removeFastaIdentifiers(alignedFasta, nonmonoInfo)
-		console.log(monophyleticFasta)
 		let beastConfig = fastaToBeast(monophyleticFasta)
 
 		expect(beastConfig).toMatchSnapshot()

--- a/server/formats/fasta/__tests__/__snapshots__/keep-identifiers.test.js.snap
+++ b/server/formats/fasta/__tests__/__snapshots__/keep-identifiers.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`removes the given identifiers from the data 1`] = `
+"> Emydura_subglobosa__KC755190
+ggaacaataaattatcacctcaaaagacac
+> Emydura_victoriae__KC755189
+ggaacaatcaattattaccccacaaagac"
+`;

--- a/server/formats/fasta/__tests__/keep-identifiers.test.js
+++ b/server/formats/fasta/__tests__/keep-identifiers.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+'use strict'
+
+const expect = require('expect')
+const keepIdentifiers = require('../keep-identifiers')
+
+test('removes the given identifiers from the data', () => {
+	let input = `> Emydura_subglobosa__KC755190
+ggaacaataaattatcacctcaaaagacac
+> Emydura_victoriae__KC755189
+ggaacaatcaattattaccccacaaagac
+> Emydura_victoriae__KC755188
+ggaacaatcaattattaccccacaaggaa`
+
+	let filteredSequences = keepIdentifiers(input, {
+		nm: [
+			[
+				{ name: 'Emydura_subglobosa', ident: 'KC755190' },
+				{ name: 'Emydura_victoriae', ident: 'KC755189' },
+			],
+		],
+	})
+
+	expect(filteredSequences).toMatchSnapshot()
+})

--- a/server/formats/fasta/index.js
+++ b/server/formats/fasta/index.js
@@ -4,10 +4,12 @@ const build = require('./build')
 const parse = require('./parse')
 const hashFastaSequenceNames = require('./hash-names')
 const removeFastaIdentifiers = require('./remove-identifiers')
+const keepFastaIdentifiers = require('./keep-identifiers')
 
 module.exports = {
 	build,
 	parse,
 	hashFastaSequenceNames,
 	removeFastaIdentifiers,
+	keepFastaIdentifiers,
 }

--- a/server/formats/fasta/keep-identifiers.js
+++ b/server/formats/fasta/keep-identifiers.js
@@ -1,0 +1,40 @@
+// @flow
+'use strict'
+
+const { parseFasta } = require('./parse')
+const { buildFasta } = require('./build')
+const flatten = require('lodash/flatten')
+
+/*::
+type EntNmPair = {
+	ident: string,
+	length: number,
+	name: string,
+}
+
+type EntNonmonophylyResults = {
+	nm: Array<[EntNmPair, EntNmPair]>,
+	species: any,
+}
+*/
+
+module.exports = keepFastaIdentifiers
+function keepFastaIdentifiers(
+	dataString /* : string */,
+	identifiers /* :EntNonmonophylyResults */
+) {
+	let samples = parseFasta(dataString)
+	let identifiersToRemove = new Set(
+		flatten(
+			identifiers.nm.map(pair =>
+				pair.map(node => `${node.name}__${node.ident}`)
+			)
+		)
+	)
+
+	let filtered = samples.filter(
+		({ species }) => identifiersToRemove.has(species)
+	)
+
+	return buildFasta(filtered)
+}

--- a/server/formats/fasta/keep-identifiers.js
+++ b/server/formats/fasta/keep-identifiers.js
@@ -32,8 +32,8 @@ function keepFastaIdentifiers(
 		)
 	)
 
-	let filtered = samples.filter(
-		({ species }) => identifiersToRemove.has(species)
+	let filtered = samples.filter(({ species }) =>
+		identifiersToRemove.has(species)
 	)
 
 	return buildFasta(filtered)

--- a/server/formats/index.js
+++ b/server/formats/index.js
@@ -17,6 +17,7 @@ module.exports = {
 	buildFasta: fasta.build,
 	hashFastaSequenceNames: fasta.hashFastaSequenceNames,
 	removeFastaIdentifiers: fasta.removeFastaIdentifiers,
+	keepFastaIdentifiers: fasta.keepFastaIdentifiers,
 	fastaToPhylip: fastaToPhylip,
 	hashNexusTreeNames: nexus.hashNexusTreeNames,
 }

--- a/server/pipeline/pipelines/mbnb.js
+++ b/server/pipeline/pipelines/mbnb.js
@@ -96,7 +96,7 @@ module.exports = [
 	},
 	{
 		// turn aligned fasta into PHYLIP
-		input: ['nonmonophyletic-aligned-fasta', 'beast-trees'],
+		input: ['aligned-fasta', 'beast-trees'],
 		transform: ([fasta, beastTrees]) => {
 			let phylipIdentMap = hashFastaSequenceNames(fasta)
 			return [

--- a/server/pipeline/pipelines/mbnb.js
+++ b/server/pipeline/pipelines/mbnb.js
@@ -10,6 +10,7 @@ const {
 	hashNexusTreeNames,
 	fastaToNexus,
 	removeFastaIdentifiers,
+	keepFastaIdentifiers,
 } = require('../../formats')
 const { pruneOutliers } = require('../../lib/prune-newick')
 const clustal = require('../../wrappers/clustal')
@@ -81,10 +82,11 @@ module.exports = [
 		// nonmonophyletic sequences before aligning
 		input: ['aligned-fasta', 'nonmonophyletic-sequences'],
 		transform: ([data, nmSeqs]) => {
-			let fasta = removeFastaIdentifiers(data, nmSeqs)
-			return [fastaToBeast(fasta), fasta]
+			let monophyleticFasta = removeFastaIdentifiers(data, nmSeqs)
+			let nonmonophyleticFasta = keepFastaIdentifiers(data, nmSeqs)
+			return [fastaToBeast(monophyleticFasta), monophyleticFasta, nonmonophyleticFasta]
 		},
-		output: ['beast-config', 'monophyletic-aligned-fasta'],
+		output: ['beast-config', 'monophyletic-aligned-fasta', 'nonmonophyletic-aligned-fasta'],
 	},
 	{
 		// generates the Species Tree used by JML
@@ -94,7 +96,7 @@ module.exports = [
 	},
 	{
 		// turn aligned fasta into PHYLIP
-		input: ['monophyletic-aligned-fasta', 'beast-trees'],
+		input: ['nonmonophyletic-aligned-fasta', 'beast-trees'],
 		transform: ([fasta, beastTrees]) => {
 			let phylipIdentMap = hashFastaSequenceNames(fasta)
 			return [

--- a/server/pipeline/pipelines/mbnb.js
+++ b/server/pipeline/pipelines/mbnb.js
@@ -84,9 +84,17 @@ module.exports = [
 		transform: ([data, nmSeqs]) => {
 			let monophyleticFasta = removeFastaIdentifiers(data, nmSeqs)
 			let nonmonophyleticFasta = keepFastaIdentifiers(data, nmSeqs)
-			return [fastaToBeast(monophyleticFasta), monophyleticFasta, nonmonophyleticFasta]
+			return [
+				fastaToBeast(monophyleticFasta),
+				monophyleticFasta,
+				nonmonophyleticFasta,
+			]
 		},
-		output: ['beast-config', 'monophyletic-aligned-fasta', 'nonmonophyletic-aligned-fasta'],
+		output: [
+			'beast-config',
+			'monophyletic-aligned-fasta',
+			'nonmonophyletic-aligned-fasta',
+		],
 	},
 	{
 		// generates the Species Tree used by JML


### PR DESCRIPTION
Currently, we pass the filtered dataset into JML, without the nonmonophyletic sequences.

With this change, we give JML the entire dataset.