### PR TITLE
Fix broken JML build step

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/amd64/node:8-stretch AS hyb-node
 
-FROM docker.io/hybsearch/jml:v1.3.1-hyb.1 AS hyb-jml
+FROM docker.io/hybsearch/jml:stretch AS hyb-jml
 
 FROM hybsearch/docker-base:v1.4 AS hyb-beast
 


### PR DESCRIPTION
I am no longer locking versions down, though I could if necessary.

We'll use the `stretch` variant for now.  Eventually I'll have a way to tag as a specific version.

This should (help) fix broken builds on #170.