### PR TITLE
Release v4.0.0 (beta 25)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybsearch/hybsearch",
-  "version": "4.0.0-beta.24",
+  "version": "4.0.0-beta.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybsearch/hybsearch",
   "private": true,
-  "version": "4.0.0-beta.24",
+  "version": "4.0.0-beta.25",
   "description": "Find nonmonophyly in genetic sequences",
   "repository": "hybsearch/hybsearch",
   "homepage": "https://hybsearch.github.io/",


### PR DESCRIPTION
Includes:

- the Vulpes dataset (#179)
- Test suite updates (#180, #181)
- Electron v2.0 (#177)
- The removal of the Left/Right columns from the JML results table (#182)
- Nicer JML result tables (spaces and things instead of all underscores) (#183)

@rye: I think we will need to clean the caches, as #182 will change the output of Ent.

We can deploy this whenever; I don't have a pressing need for it.