### PR TITLE
Speed up Ent searches

### DIFF
--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -205,7 +205,12 @@ function recursiveSearch(node, nmInstances = []) {
 			speciesListB.forEach(speciesChecker(speciesListA))
 			remove(speciesListB, n => forRemoval.includes(n.ident))
 
-			speciesList = [...speciesList, ...speciesListA, ...speciesListB]
+			if (speciesListA.length) {
+				speciesList.push(...speciesListA)
+			}
+			if (speciesListB.length) {
+				speciesList.push(...speciesListB)
+			}
 		}
 
 		speciesList = uniqBy(speciesList, 'ident')


### PR DESCRIPTION
As I've complained about a few times recently, we have a few inputs files now that can take up to ~30s in Ent searching.

```
 PASS  ent/__tests__/ent.test.js (39.611s)
  ✓ bataguridae-cytb (34317ms)
  ✓ catdog (2ms)
  ✓ coyote-test (3ms)
  ✓ emydura-short (1ms)
  ✓ kino (3ms)
  ✓ lepomis (1399ms)
  ✓ pelomedusidae-cytb (2608ms)
  ✓ plaamyd (1ms)
  ✓ pseudemyscytbplushnfal (1ms)
  ✓ smallerlepus (1ms)
  ✓ trio171sequence (17ms)
  ✓ trionychcytb (259ms)
  ✓ vulpes (690ms)
```

Well, with this PR, we instead have these results:

```
 PASS  ent/__tests__/ent.test.js
  ✓ bataguridae-cytb (1437ms)
  ✓ catdog (1ms)
  ✓ coyote-test (2ms)
  ✓ emydura-short (1ms)
  ✓ kino (2ms)
  ✓ lepomis (76ms)
  ✓ pelomedusidae-cytb (62ms)
  ✓ plaamyd (2ms)
  ✓ pseudemyscytbplushnfal
  ✓ smallerlepus (2ms)
  ✓ trio171sequence (11ms)
  ✓ trionychcytb (96ms)
  ✓ vulpes (22ms)
```

Why, you may ask? I went and profiled the Bataguridae search, and I came up with this flame graph:

![screen shot 2018-05-17 at 2 24 32 am](https://user-images.githubusercontent.com/464441/40162382-79264720-5979-11e8-85a6-ea6b88e6533a.png)

The two largest blocks on that graph are both within V8's C++ code: one is `ArrayIteratorPrototypeNext`, which has something to do with array iteration, and one is T `v8::internal::Runtime_AppendElement`, which … probably has something to do with appending elements?

So I added some logging to see how big speciesList got, and it was pretty big, and I knew that it was copied here, so I decided to try to optimize that copy. 

And, well. It worked! This cuts our worst-case ent runtime (on bataguridae) from ~34s to ~1.5s.

It's not that the spread operator (`[…x]`) is badly optimized; we're just copying like 28,000,000 objects at certain points in here (I may be off by one zero, but there were a lot of numbers when I was logging that.)

![screen shot 2018-05-17 at 2 25 10 am](https://user-images.githubusercontent.com/464441/40162406-8a1225cc-5979-11e8-802b-ed8731712f57.png)

You can actually see the initialization stuff on the left now!

Anyway. Yay for easy fixes! (Well, easy to implement; not so easy to find the first time.)