### PR TITLE
add an ASCII-art newick-tree-printer library/binary

### DIFF
--- a/server/newick/hyb-newick-pretty
+++ b/server/newick/hyb-newick-pretty
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+'use strict'
+
+const getData = require('../lib/get-data')
+const parseNewick = require('./parser')
+const prettyPrintNewickTree = require('./printer')
+
+function main() {
+	let file = process.argv[2]
+
+	if (!file && process.stdin.isTTY) {
+		console.error('usage: hyb-newick-pretty (<input> | -)')
+		process.exit(1)
+	}
+
+	return getData(file)
+		.then(parseNewick)
+		.then(prettyPrintNewickTree)
+		.then(console.log)
+		.catch(console.error)
+}
+
+if (require.main === module) {
+	main()
+}

--- a/server/newick/printer.js
+++ b/server/newick/printer.js
@@ -1,0 +1,100 @@
+// @flow
+const zip = require('lodash/zip')
+
+function asciiArt(node, options={}) {
+	let {
+		char = '-',
+		showInternal = false,
+		compact = false,
+		attributes = null,
+	} = options
+
+	// Returns the ASCII representation of the tree.
+	// Based on the Ete project; this funciton was derived from
+	// https://github.com/etetoolkit/ete/blob/da6a23ae7adbe98be26a232a29fd90af3a66b0b5/ete3/coretype/tree.py
+	if (!attributes) {
+		attributes = ['name']
+	}
+
+	let nodeName = attributes
+		.map(key => (node.hasOwnProperty(key) ? node[key] : null))
+		.filter(val => val !== null)
+		.map(String)
+		.join(', ')
+
+	let LEN = Math.max(3, !(node.branchset || showInternal) ? nodeName.length : 3)
+	let PAD = ' '.repeat(LEN)
+	let PA = ' '.repeat(LEN - 1)
+
+	if (!node.branchset) {
+		return { lines: [char + '-' + nodeName], mid: 0 }
+	}
+
+	let mids = []
+	let result = []
+	for (let c of node.branchset) {
+		let char2 = '-'
+		if (node.branchset.length === 1) {
+			char2 = '/'
+		} else if (c === node.branchset[0]) {
+			char2 = '/'
+		} else if (c === node.branchset[node.branchset.length - 1]) {
+			char2 = '\\'
+		}
+
+		let { lines: childLines, mid } = asciiArt(c, {
+			char: char2,
+			showInternal,
+			compact,
+			attributes,
+		})
+
+		mids.push(mid + result.length)
+		result = [...result, ...childLines]
+		if (!compact) {
+			result.push('')
+		}
+	}
+
+	if (!compact) {
+		result.pop()
+	}
+
+	let lo = mids[0]
+	let hi = mids[mids.length - 1]
+	let end = result.length
+
+	let prefixes = [
+		...new Array(lo + 1).fill(PAD),
+		...new Array(hi - lo - 1).fill(PA + '|'),
+		...new Array(end - hi).fill(PAD),
+	]
+
+	let mid = Math.trunc((lo + hi) / 2)
+	prefixes[mid] =
+		char + '-'.repeat(LEN - 2) + prefixes[mid][prefixes[mid].length - 1]
+
+	result = zip(prefixes, result).map(([p, l]) => p + l)
+
+	// console.log(result)
+
+	if (showInternal) {
+		let stem = result[mid]
+		result[mid] = stem[0] + nodeName + stem.slice(nodeName.length + 1)
+	}
+
+	return { lines: result, mid }
+}
+
+/*::
+type NewickNode = {
+	branchset?: Array<NewickNode>,
+	name: string,
+	length: number,
+}
+*/
+
+module.exports = prettyPrintNewickTree
+function prettyPrintNewickTree(rootNode /*: NewickNode*/) {
+	return asciiArt(rootNode).lines.join('\n')
+}

--- a/server/newick/printer.js
+++ b/server/newick/printer.js
@@ -1,7 +1,7 @@
 // @flow
 const zip = require('lodash/zip')
 
-function asciiArt(node, options={}) {
+function asciiArt(node, options = {}) {
 	let {
 		char = '-',
 		showInternal = false,


### PR DESCRIPTION
![telegram-cloud-file-3-831937820-81551-8989833990133310411](https://user-images.githubusercontent.com/464441/40207830-1f2a814a-59fc-11e8-9202-b33d7a9da5bb.jpg)

`/server/newick/hyb-newick-pretty kino.tree` will output a formatted tree to the terminal.

May be useful if you need to look at a Newick tree.