### PR TITLE
un-hide the tree when loading a json tree

### DIFF
--- a/electron/run.js
+++ b/electron/run.js
@@ -145,6 +145,7 @@ function attachListeners() {
 			e.preventDefault()
 
 			let data = document.getElementById('tree-box').value
+			document.querySelector('#phylogram').hidden = false
 			load(JSON.parse(data))
 		})
 


### PR DESCRIPTION
it was never unhidden otherwise