### PR TITLE
Fix a bug where the list of files would double in length

### DIFF
--- a/electron/ui.js
+++ b/electron/ui.js
@@ -116,6 +116,7 @@ function populateFilePicker(files) {
 	)
 
 	const picker = document.querySelector('#pick-file')
+	picker.innerHTML = ''
 
 	for (let [type, options] of toPairs(optgroups)) {
 		let group = document.createElement('optgroup')


### PR DESCRIPTION
Every time you changed servers, the list of files would get appended.