### PR TITLE
Pass options to pipeline

### DIFF
--- a/electron/index.css
+++ b/electron/index.css
@@ -185,7 +185,8 @@ button:active {
 }
 
 input[type='text'],
-input[type='url'] {
+input[type='url'],
+input[type='number'] {
 	padding: 10px 15px;
 }
 

--- a/electron/index.css
+++ b/electron/index.css
@@ -284,3 +284,7 @@ summary > h3 {
 .results-table .highlight {
 	background-color: lightyellow;
 }
+
+.row {
+	margin-bottom: 2em;
+}

--- a/electron/index.html
+++ b/electron/index.html
@@ -33,6 +33,10 @@
 					<option>No pipelines present</option>
 				</select>
 			</div>
+			<div class="row" id="options" hidden>
+				<h3>Options</h3>
+				<div class="options"></div>
+			</div>
 			<div class="row">
 				<button id="start">Run Hybsearch</button>
 			</div>

--- a/electron/index.html
+++ b/electron/index.html
@@ -35,7 +35,7 @@
 			</div>
 			<div class="row" id="options" hidden>
 				<h3>Options</h3>
-				<div class="options"></div>
+				<form class="options"></form>
 			</div>
 			<div class="row">
 				<button id="start">Run Hybsearch</button>

--- a/electron/index.html
+++ b/electron/index.html
@@ -12,25 +12,30 @@
 
 		<section id="file-input">
 			<h2>Genbank/Fasta</h2>
-			<input type="file" id="load-file" accept=".gb,.genbank,.fasta">
-			<select id="pick-file">
-				<option>No file chosen</option>
-			</select>
-			<br/><br/>
-			<span id="server-status" class="down"></span>
-			<label>
-				Server:
-				<input type="url" id="server-url" value="ws://localhost:8080/" placeholder="ws://server:port/">
-			</label>
-			<button id="use-thing3" data-url="ws://thing3.cs.stolaf.edu:80/">Use Thing3</button>
-			<button id="use-localhost" data-url="ws://localhost:8080/">Use localhost</button>
-			<br/><br/>
-			<label for="pick-pipeline">Pipeline:</label>
-			<select id="pick-pipeline">
-				<option>No pipelines present</option>
-			</select>
-			<br/><br/>
-			<button id="start">Run Hybsearch</button>
+			<div class="row">
+				<input type="file" id="load-file" accept=".gb,.genbank,.fasta">
+				<select id="pick-file">
+					<option>No file chosen</option>
+				</select>
+			</div>
+			<div class="row">
+				<span id="server-status" class="down"></span>
+				<label>
+					Server:
+					<input type="url" id="server-url" value="ws://localhost:8080/" placeholder="ws://server:port/">
+				</label>
+				<button id="use-thing3" data-url="ws://thing3.cs.stolaf.edu:80/">Use Thing3</button>
+				<button id="use-localhost" data-url="ws://localhost:8080/">Use localhost</button>
+			</div>
+			<div class="row">
+				<label for="pick-pipeline">Pipeline:</label>
+				<select id="pick-pipeline">
+					<option>No pipelines present</option>
+				</select>
+			</div>
+			<div class="row">
+				<button id="start">Run Hybsearch</button>
+			</div>
 		</section>
 
 		<section id="newick-input">

--- a/electron/run.js
+++ b/electron/run.js
@@ -31,7 +31,10 @@ function run() {
 
 	// get the pipeline options
 	let options = document.querySelector('#options .options')
-	let opts = Array.from(...options.elements).map(el => [el.name, el.type === 'number' ? Number(el.value) : el.value])
+	let opts = Array.from(...options.elements).map(el => [
+		el.name,
+		el.type === 'number' ? Number(el.value) : el.value,
+	])
 	opts = fromPairs(opts)
 
 	// start the pipeline
@@ -40,7 +43,13 @@ function run() {
 	return false
 }
 
-function submitJob({ socket = global.socket, pipeline, filepath, data, options }) {
+function submitJob({
+	socket = global.socket,
+	pipeline,
+	filepath,
+	data,
+	options,
+}) {
 	const ws = socket
 
 	ws.addEventListener('message', packet => onMessage(packet.data))

--- a/electron/run.js
+++ b/electron/run.js
@@ -31,7 +31,7 @@ function run() {
 
 	// get the pipeline options
 	let options = document.querySelector('#options .options')
-	let opts = Array.from(...options.elements).map(el => [
+	let opts = Array.from(options.elements).map(el => [
 		el.name,
 		el.type === 'number' ? Number(el.value) : el.value,
 	])

--- a/electron/run.js
+++ b/electron/run.js
@@ -4,6 +4,7 @@ const { load, setEntResults } = require('./graph')
 const makeTableFromObjectList = require('./lib/html-table')
 const prettyMs = require('pretty-ms')
 const fs = require('fs')
+const fromPairs = require('lodash/fromPairs')
 
 function run() {
 	// get the file
@@ -28,13 +29,18 @@ function run() {
 	// get the chosen pipeline name
 	let pipeline = document.querySelector('#pick-pipeline').value
 
+	// get the pipeline options
+	let options = document.querySelector('#options .options')
+	let opts = Array.from(...options.elements).map(el => [el.name, el.type === 'number' ? Number(el.value) : el.value])
+	opts = fromPairs(opts)
+
 	// start the pipeline
-	submitJob({ pipeline, filepath, data })
+	submitJob({ pipeline, filepath, data, options: opts })
 
 	return false
 }
 
-function submitJob({ socket = global.socket, pipeline, filepath, data }) {
+function submitJob({ socket = global.socket, pipeline, filepath, data, options }) {
 	const ws = socket
 
 	ws.addEventListener('message', packet => onMessage(packet.data))
@@ -48,7 +54,7 @@ function submitJob({ socket = global.socket, pipeline, filepath, data }) {
 		throw new Error('socket not ready!')
 	}
 
-	let payload = { type: 'start', pipeline, filepath, data }
+	let payload = { type: 'start', pipeline, filepath, data, options }
 	ws.send(JSON.stringify(payload), err => {
 		if (err) {
 			console.error('server error', err)

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -155,4 +155,23 @@ const handleNewSteps = payload => {
 				</div>`
 		)
 		.join('')
+
+	let optionsEl = document.querySelector('#options')
+	let optionsContainer = optionsEl.querySelector('.options')
+	let options = Object.entries(payload.options).map(
+		([key, val]) => `
+		<div class="option-row">
+			<label>${val.label}: <input name="${key}" type="${val.type}" value="${
+			val.default
+		}" placeholder="${val.description}"></label>
+		</div>
+	`
+	)
+	if (options.length) {
+		optionsEl.removeAttribute('hidden')
+		optionsContainer.innerHTML = options.join('')
+	} else {
+		optionsEl.setAttribute('hidden', 'hidden')
+		optionsContainer.innerHTML = ''
+	}
 }

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -159,13 +159,11 @@ const handleNewSteps = payload => {
 	let optionsEl = document.querySelector('#options')
 	let optionsContainer = optionsEl.querySelector('.options')
 	let options = Object.entries(payload.options).map(
-		([key, val]) => `
-		<div class="option-row">
-			<label>${val.label}: <input name="${key}" type="${val.type}" value="${
-			val.default
-		}" placeholder="${val.description}"></label>
-		</div>
-	`
+		([key, val]) =>
+			// prettier-ignore
+			`<div class="option-row">
+				<label>${val.label}: <input name="${key}" type="${val.type}" value="${val.default}" placeholder="${val.description}"></label>
+			</div>`
 	)
 	if (options.length) {
 		optionsEl.removeAttribute('hidden')

--- a/server/formats/fasta-to-beast.js
+++ b/server/formats/fasta-to-beast.js
@@ -44,7 +44,7 @@ function fastaToBeast(fastaData) {
 	let seqs = items.map(({ species, sequence }) => {
 		let id = `seq_${species}1`
 		let taxon = species
-		let count = 4 // TODO: setting to 4 until we how to compute it
+		let count = 4 // TODO: setting to 4 until we know how to compute it
 		let value = sequence
 		return `\t<sequence id="${id}" taxon="${taxon}" totalcount="${count}" value="${value}"/>`
 	})

--- a/server/formats/fasta-to-beast.js
+++ b/server/formats/fasta-to-beast.js
@@ -37,7 +37,7 @@ function inflateTemplate(vars) {
 }
 
 module.exports = fastaToBeast
-function fastaToBeast(fastaData) {
+function fastaToBeast(fastaData, { chainLength = '10000000' } = {}) {
 	let items = parseFasta(fastaData)
 	items = sortBy(items, ({ species }) => species)
 
@@ -68,5 +68,6 @@ function fastaToBeast(fastaData) {
 		filename: 'data',
 		sequences: seqs.join('\n'),
 		taxon: taxon.join('\n'),
+		chainLength: chainLength,
 	})
 }

--- a/server/formats/template.xml
+++ b/server/formats/template.xml
@@ -16,7 +16,7 @@
 <map name="InverseGamma">beast.math.distributions.InverseGamma</map>
 <map name="OneOnX">beast.math.distributions.OneOnX</map>
 
-<run id="mcmc" spec="MCMC" chainLength="10000000" storeEvery="5000">
+<run id="mcmc" spec="MCMC" chainLength="{{chainLength}}" storeEvery="5000">
 	<state id="state" storeEvery="5000">
 		<parameter id="popSize" name="stateNode">1.0</parameter>
 		<tree id="Tree.t:Species" name="stateNode">

--- a/server/lib/prune-newick.js
+++ b/server/lib/prune-newick.js
@@ -12,7 +12,7 @@ module.exports.removeNodes = removeNodes
 function pruneOutliers(
 	newick,
 	alignedFasta,
-	{ outlierRemovalPercentage = 0.5 }
+	{ outlierRemovalPercentage = 0.5 } = {}
 ) {
 	const fastaData = parseFasta(alignedFasta)
 	// Build a dict map of species -> sequence

--- a/server/pipeline/cache.js
+++ b/server/pipeline/cache.js
@@ -8,21 +8,24 @@ const slashEscape = require('slash-escape')
 const mkdir = require('make-dir')
 
 class Cache {
-	constructor({ filepath, contents, pipelineName }) {
+	constructor({ filepath, contents, pipelineName, options }) {
 		this.filepath = filepath
 		this.data = contents
 		this.pipelineName = pipelineName
-		this.dataHash = this.hash(this.data)
+		this.options = options
+
+		this.hashKey = this.hash(
+			`${this.pipelineName}${JSON.stringify(this.options)}`
+		)
+		this.dataHash = this.hash(`${this.hashKey}:${this.data}`)
 
 		this.get = this.get.bind(this)
 		this.set = this.set.bind(this)
+		this.hash = this.hash.bind(this)
+		this.diskFilename = this.diskFilename.bind(this)
 
-		if (!process.env.DOCKER) {
-			this.cacheDir = tempy.directory()
-		} else {
-			let name = slashEscape.escape(pipelineName)
-			this.cacheDir = mkdir.sync(`/tmp/hybsearch/${name}/${this.dataHash}`)
-		}
+		let cacheRoot = process.env.DOCKER ? `/tmp/hybsearch` : tempy.directory()
+		this.cacheDir = mkdir.sync(`${cacheRoot}/${this.dataHash}`)
 
 		this.set('source', { filepath: this.filepath, contents: this.data })
 	}

--- a/server/pipeline/pipelines/beast.js
+++ b/server/pipeline/pipelines/beast.js
@@ -15,7 +15,9 @@ const beast = require('../../wrappers/beast')
 const jml = require('../../wrappers/jml')
 const { removeCircularLinks } = require('../lib')
 
-module.exports = [
+let options = {}
+
+let steps = [
 	{
 		// the first step: ensures that the input is converted to FASTA
 		input: ['source'],
@@ -99,3 +101,5 @@ module.exports = [
 		output: ['jml-output'],
 	},
 ]
+
+module.exports = { steps, options }

--- a/server/pipeline/pipelines/index.js
+++ b/server/pipeline/pipelines/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports.mbnb = require('./mbnb.js')
-module.exports['mbnb-legacy'] = require('./mbnb.js')
+module.exports['mbnb-legacy'] = require('./mbnb-legacy.js')
 module.exports.beast = require('./beast.js')
 module.exports.search = require('./search.js')
 module.exports['parse-newick'] = require('./parse-newick.js')

--- a/server/pipeline/pipelines/mbnb-legacy.js
+++ b/server/pipeline/pipelines/mbnb-legacy.js
@@ -19,7 +19,9 @@ const jml = require('../../wrappers/jml')
 const mrBayes = require('../../wrappers/mrbayes')
 const { removeCircularLinks } = require('../lib')
 
-module.exports = [
+let options = {}
+
+let steps = [
 	{
 		// the first step: ensures that the input is converted to FASTA
 		input: ['source'],
@@ -128,3 +130,5 @@ module.exports = [
 		output: ['jml-output'],
 	},
 ]
+
+module.exports = { steps, options }

--- a/server/pipeline/pipelines/mbnb.js
+++ b/server/pipeline/pipelines/mbnb.js
@@ -19,7 +19,16 @@ const jml = require('../../wrappers/jml')
 const mrBayes = require('../../wrappers/mrbayes')
 const { removeCircularLinks } = require('../lib')
 
-module.exports = [
+let options = {
+	outlierRemovalPercentage: {
+		default: 0.5,
+		type: 'number',
+		label: 'outlierRemovalPercentage',
+		description: 'desc',
+	},
+}
+
+let steps = [
 	{
 		// the first step: ensures that the input is converted to FASTA
 		input: ['source'],
@@ -128,3 +137,5 @@ module.exports = [
 		output: ['jml-output'],
 	},
 ]
+
+module.exports = { steps, options }

--- a/server/pipeline/pipelines/mbnb.js
+++ b/server/pipeline/pipelines/mbnb.js
@@ -26,6 +26,12 @@ let options = {
 		label: 'outlierRemovalPercentage',
 		description: 'desc',
 	},
+	beastChainLength: {
+		default: '10000000',
+		type: 'text',
+		label: "BEAST's 'chainLength' parameter",
+		description: 'another desc',
+	},
 }
 
 let steps = [
@@ -91,11 +97,11 @@ let steps = [
 		// converts the aligned FASTA into Nexus for BEAST, and removes the
 		// nonmonophyletic sequences before aligning
 		input: ['aligned-fasta', 'nonmonophyletic-sequences'],
-		transform: ([data, nmSeqs]) => {
+		transform: ([data, nmSeqs], { beastChainLength }) => {
 			let monophyleticFasta = removeFastaIdentifiers(data, nmSeqs)
 			let nonmonophyleticFasta = keepFastaIdentifiers(data, nmSeqs)
 			return [
-				fastaToBeast(monophyleticFasta),
+				fastaToBeast(monophyleticFasta, { chainLength: beastChainLength }),
 				monophyleticFasta,
 				nonmonophyleticFasta,
 			]

--- a/server/pipeline/pipelines/mbnb.js
+++ b/server/pipeline/pipelines/mbnb.js
@@ -68,10 +68,11 @@ let steps = [
 	},
 	{
 		input: ['newick-json:1', 'aligned-fasta'],
-		transform: ([newickJson, alignedFasta]) => {
+		transform: ([newickJson, alignedFasta], { outlierRemovalPercentage }) => {
 			let { removedData, prunedNewick } = pruneOutliers(
 				newickJson,
-				alignedFasta
+				alignedFasta,
+				{ outlierRemovalPercentage }
 			)
 			return [prunedNewick, removedData]
 		},

--- a/server/pipeline/pipelines/parse-newick.js
+++ b/server/pipeline/pipelines/parse-newick.js
@@ -2,7 +2,9 @@
 
 const { parse: parseNewick } = require('../../newick')
 
-module.exports = [
+let options = {}
+
+let steps = [
 	{
 		// turns the Newick tree into a JSON object
 		input: ['source'],
@@ -10,3 +12,5 @@ module.exports = [
 		output: ['newick-json:1'],
 	},
 ]
+
+module.exports = { steps, options }

--- a/server/pipeline/pipelines/search.js
+++ b/server/pipeline/pipelines/search.js
@@ -8,7 +8,9 @@ const clustal = require('../../wrappers/clustal')
 const mrBayes = require('../../wrappers/mrbayes')
 const { removeCircularLinks } = require('../lib')
 
-module.exports = [
+let options = {}
+
+let steps = [
 	{
 		// the first step: ensures that the input is converted to FASTA
 		input: ['source'],
@@ -67,3 +69,5 @@ module.exports = [
 		output: ['nonmonophyletic-sequences', 'newick-json:3'],
 	},
 ]
+
+module.exports = { steps, options }

--- a/server/pipeline/worker.js
+++ b/server/pipeline/worker.js
@@ -66,7 +66,7 @@ async function main({ pipeline: pipelineName, filepath, data, options }) {
 		defaults = fromPairs(
 			toPairs(defaults).map(([key, value]) => [key, value.default])
 		)
-		options = {...defaults, ...options}
+		options = { ...defaults, ...options }
 
 		let cache = new Cache({ filepath, contents: data, pipelineName, options })
 

--- a/server/pipeline/worker.js
+++ b/server/pipeline/worker.js
@@ -54,7 +54,7 @@ process.on('disconnect', () => {
 ///// pipeline
 /////
 
-async function main({ pipeline: pipelineName, filepath, data }) {
+async function main({ pipeline: pipelineName, filepath, data, options }) {
 	let start = now()
 
 	try {
@@ -62,10 +62,11 @@ async function main({ pipeline: pipelineName, filepath, data }) {
 			data = await loadFile(filepath)
 		}
 
-		let { steps, options } = PIPELINES[pipelineName]
-		options = fromPairs(
-			toPairs(options).map(([key, value]) => [key, value.default])
+		let { steps, options: defaults } = PIPELINES[pipelineName]
+		defaults = fromPairs(
+			toPairs(defaults).map(([key, value]) => [key, value.default])
 		)
+		options = {...defaults, ...options}
 
 		let cache = new Cache({ filepath, contents: data, pipelineName, options })
 

--- a/server/pipeline/worker.js
+++ b/server/pipeline/worker.js
@@ -92,7 +92,7 @@ async function main({ pipeline: pipelineName, filepath, data }) {
 				continue
 			}
 
-			let results = await Promise.all(await step.transform(inputs))
+			let results = await Promise.all(await step.transform(inputs, options))
 
 			// assert(results.length === step.output.length)
 			zip(step.output, results).forEach(([key, result]) => {

--- a/server/server.js
+++ b/server/server.js
@@ -35,7 +35,7 @@ router.get('/pipelines', ctx => {
 router.get('/pipeline/:name', ctx => {
 	let pipe = PIPELINES[ctx.params.name]
 	if (pipe) {
-		ctx.body = { steps: pipe }
+		ctx.body = { steps: pipe.steps, options: pipe.options || {} }
 	} else {
 		ctx.throw(404, { error: 'pipeline not found' })
 	}


### PR DESCRIPTION
This handles:

- specifying options in the pipeline
- rendering options in the UI
- passing options to the transform() functions, so that they can be passed to the actual functions

@OmarShehata, are the changes to `prune-newick` in https://github.com/hybsearch/hybsearch/pull/203/commits/7c6b3bf8646139a8ba486676262310db0be75162 correct for what we want to change, or do we need to change another field?

~~I should probably add one for BEAST repetitions, too.~~ Done as of 77bc599.

<details><summary>This also restructures the cache once more</summary>

it's now

```
/tmp/hybsearch/$combinedDataAndOptionsHash/$slashEscapedStepName
```

instead of

```
/tmp/hybsearch/$slashEscapedPipelineName/$dataHash/$slashEscapedStepName
```

</details>

---

~~I just realized that I forgot to actually send the options to the server. That'll have to happen tomorrow.~~ 
~~This may now be completed. My local copy is busy running felidæ, so I haven't tested the send-options-to-server commits yet.~~
This has been completed.