### PR TITLE
Highlight significant nonmonophyly in a separate results box

### DIFF
--- a/electron/index.html
+++ b/electron/index.html
@@ -61,6 +61,11 @@
 			<p>The following sequences were omitted because they were more than 20% different when compared with a majority of the sequences.</p>
 		</section>
 
+		<section hidden id="significant-nonmonophyly-container">
+			<h2>Significant Nonmonophyly</h2>
+			<div id="significant-nonmonophyly"></div>
+		</section>
+
 		<section hidden id="nm-container">
 			<h2>Nonmonophyly</h2>
 			<div id="nonmonophyly-results"></div>

--- a/electron/run.js
+++ b/electron/run.js
@@ -80,23 +80,17 @@ function onData(phase, data) {
 		let container = document.querySelector('#jml-container')
 		container.hidden = false
 
-		document
-			.querySelector('#distributions')
-			.appendChild(makeTableFromObjectList(data.distributions))
+		let distributions = document.querySelector('#distributions')
+		distributions.innerHTML = ''
+		distributions.appendChild(makeTableFromObjectList(data.distributions))
 
-		document
-			.querySelector('#probabilities')
-			.appendChild(makeTableFromObjectList(data.probabilities))
+		let probabilities = document.querySelector('#probabilities')
+		probabilities.innerHTML = ''
+		probabilities.appendChild(makeTableFromObjectList(data.probabilities))
 
-		data.results = data.results.map(item => {
-			if (item.Probability < 0.05) {
-				return Object.assign({}, item, { __highlight: true })
-			}
-			return item
-		})
-		document
-			.querySelector('#results')
-			.appendChild(makeTableFromObjectList(data.results))
+		let results = document.querySelector('#results')
+		results.innerHTML = ''
+		results.appendChild(makeTableFromObjectList(data.results))
 	} else if (phase === 'nonmonophyletic-sequences') {
 		setEntResults(data)
 	} else {

--- a/electron/run.js
+++ b/electron/run.js
@@ -94,6 +94,15 @@ function onData(phase, data) {
 		results.appendChild(makeTableFromObjectList(data.results))
 	} else if (phase === 'nonmonophyletic-sequences') {
 		setEntResults(data)
+	} else if (phase === 'significant-nonmonophyly') {
+		let container = document.querySelector(
+			'#significant-nonmonophyly-container'
+		)
+		container.hidden = false
+
+		let results = container.querySelector('#significant-nonmonophyly')
+		results.innerHTML = ''
+		results.appendChild(makeTableFromObjectList(data))
 	} else {
 		console.warn(`Client doesn't understand data for "${phase}"`)
 	}

--- a/electron/run.js
+++ b/electron/run.js
@@ -73,6 +73,7 @@ function onData(phase, data) {
 		})
 
 		if (formattedNames.length > 0) {
+			container.innerHTML = ''
 			container.hidden = false
 			container.appendChild(makeTableFromObjectList(formattedNames))
 		}

--- a/server/lib/__tests__/__snapshots__/find-significant-nonmonophyly-test.js.snap
+++ b/server/lib/__tests__/__snapshots__/find-significant-nonmonophyly-test.js.snap
@@ -3,6 +3,7 @@
 exports[`handles more than one case 1`] = `
 Array [
   Object {
+    "__highlight": true,
     "distance": 0.0154211,
     "probability": 0.023988,
     "seq1": "Emydura tanybaraga [KC755186]",
@@ -14,12 +15,14 @@ Array [
 exports[`only returns the highlighted sequences 1`] = `
 Array [
   Object {
+    "__highlight": true,
     "distance": 0.0130486,
     "probability": 0.0214893,
     "seq1": "Emydura tanybaraga [KC755187]",
     "seq2": "Emydura subglobosa [KC755184]",
   },
   Object {
+    "__highlight": true,
     "distance": 0.0154211,
     "probability": 0.023988,
     "seq1": "Emydura tanybaraga [KC755186]",

--- a/server/lib/__tests__/__snapshots__/find-significant-nonmonophyly-test.js.snap
+++ b/server/lib/__tests__/__snapshots__/find-significant-nonmonophyly-test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`handles more than one case 1`] = `
+Array [
+  Object {
+    "distance": 0.0154211,
+    "probability": 0.023988,
+    "seq1": "Emydura tanybaraga [KC755186]",
+    "seq2": "Emydura subglobosa [KC755184]",
+  },
+]
+`;
+
+exports[`only returns the highlighted sequences 1`] = `
+Array [
+  Object {
+    "distance": 0.0130486,
+    "probability": 0.0214893,
+    "seq1": "Emydura tanybaraga [KC755187]",
+    "seq2": "Emydura subglobosa [KC755184]",
+  },
+  Object {
+    "distance": 0.0154211,
+    "probability": 0.023988,
+    "seq1": "Emydura tanybaraga [KC755186]",
+    "seq2": "Emydura subglobosa [KC755184]",
+  },
+]
+`;

--- a/server/lib/__tests__/find-significant-nonmonophyly-test.js
+++ b/server/lib/__tests__/find-significant-nonmonophyly-test.js
@@ -1,0 +1,122 @@
+/* eslint-env jest */
+
+const {
+	findSignificantNonmonophyly,
+} = require('../find-significant-nonmonophyly')
+
+test('only returns the highlighted sequences', () => {
+	let jml = {
+		distributions: [],
+		probabilities: [],
+		results: [
+			{
+				seq1: 'Emydura victoriae [KC755188]',
+				seq2: 'Emydura subglobosa [KC755184]',
+				Distance: 0.0996441,
+				Probability: 0.971514,
+			},
+			{
+				seq1: 'Emydura tanybaraga [KC755187]',
+				seq2: 'Emydura subglobosa [KC755184]',
+				Distance: 0.0130486,
+				Probability: 0.0214893,
+				__highlight: true,
+			},
+			{
+				seq1: 'Emydura tanybaraga [KC755186]',
+				seq2: 'Emydura subglobosa [KC755190]',
+				Distance: 0.0640569,
+				Probability: 0.796602,
+			},
+			{
+				seq1: 'Emydura tanybaraga [KC755186]',
+				seq2: 'Emydura subglobosa [KC755185]',
+				Distance: 0.0699881,
+				Probability: 0.89905,
+			},
+			{
+				seq1: 'Emydura tanybaraga [KC755186]',
+				seq2: 'Emydura subglobosa [KC755184]',
+				Distance: 0.0154211,
+				Probability: 0.023988,
+				__highlight: true,
+			},
+		],
+	}
+
+	let ent = {
+		nm: [
+			{
+				name: 'Emydura_subglobosa',
+				length: 0.008548827,
+				ident: 'KC755184',
+			},
+		],
+		species: [],
+	}
+
+	let actual = findSignificantNonmonophyly(jml, ent)
+
+	expect(actual).toHaveLength(2)
+
+	expect(actual).toMatchSnapshot()
+})
+
+test('handles more than one case', () => {
+	// this test is much the same as 'only returns the highlighted sequences'
+	let jml = {
+		distributions: [],
+		probabilities: [],
+		results: [
+			{
+				seq1: 'Emydura victoriae [KC755188]',
+				seq2: 'Emydura subglobosa [KC755184]',
+				Distance: 0.0996441,
+				Probability: 0.971514,
+			},
+			{
+				seq1: 'Emydura tanybaraga [KC755187]',
+				seq2: 'Emydura subglobosa [KC755184]',
+				Distance: 0.0130486,
+				Probability: 0.0214893,
+				__highlight: true,
+			},
+			{
+				seq1: 'Emydura tanybaraga [KC755186]',
+				seq2: 'Emydura subglobosa [KC755190]',
+				Distance: 0.0640569,
+				Probability: 0.796602,
+			},
+			{
+				seq1: 'Emydura tanybaraga [KC755186]',
+				seq2: 'Emydura subglobosa [KC755185]',
+				Distance: 0.0699881,
+				Probability: 0.89905,
+			},
+			{
+				seq1: 'Emydura tanybaraga [KC755186]',
+				seq2: 'Emydura subglobosa [KC755184]',
+				Distance: 0.0154211,
+				Probability: 0.023988,
+				__highlight: true,
+			},
+		],
+	}
+
+	let ent = {
+		nm: [
+			{
+				name: 'Emydura_subglobosa',
+				length: 0.008548827,
+				ident: 'KC755186',
+			},
+		],
+		species: [],
+	}
+
+	let actual = findSignificantNonmonophyly(jml, ent)
+
+	expect(actual).toHaveLength(1)
+
+	expect(actual).toMatchSnapshot()
+})

--- a/server/lib/find-significant-nonmonophyly.js
+++ b/server/lib/find-significant-nonmonophyly.js
@@ -1,0 +1,25 @@
+module.exports.findSignificantNonmonophyly = findSignificantNonmonophyly
+function findSignificantNonmonophyly(jmlOutput, nmSequencesFromEnt) {
+	let highlighted = jmlOutput.results.filter(entry => entry.__highlight)
+
+	let jmlNm = nmSequencesFromEnt.nm.map(seq => seq.ident)
+
+	let highlightedAndFiltered = highlighted.filter(entry =>
+		jmlNm
+			.map(nmIndent => `[${nmIndent}]`)
+			.some(
+				nmIndent =>
+					entry.seq1.includes(nmIndent) || entry.seq2.includes(nmIndent)
+			)
+	)
+
+	let cleaned = highlightedAndFiltered.map(entry => ({
+		seq1: entry.seq1,
+		seq2: entry.seq2,
+		distance: entry.Distance,
+		probability: entry.Probability,
+		__highlight: entry.__highlight,
+	}))
+
+	return cleaned
+}

--- a/server/pipeline/pipelines/mbnb.js
+++ b/server/pipeline/pipelines/mbnb.js
@@ -13,6 +13,9 @@ const {
 	keepFastaIdentifiers,
 } = require('../../formats')
 const { pruneOutliers } = require('../../lib/prune-newick')
+const {
+	findSignificantNonmonophyly,
+} = require('../../lib/find-significant-nonmonophyly')
 const clustal = require('../../wrappers/clustal')
 const beast = require('../../wrappers/beast')
 const jml = require('../../wrappers/jml')
@@ -126,5 +129,13 @@ module.exports = [
 			}),
 		],
 		output: ['jml-output'],
+	},
+	{
+		// find the significant nonmonophetic sequences
+		input: ['jml-output', 'nonmonophyletic-sequences'],
+		transform: ([jmlOutput, nmSequences]) => [
+			findSignificantNonmonophyly(jmlOutput, nmSequences),
+		],
+		output: ['significant-nonmonophyly'],
 	},
 ]

--- a/server/wrappers/jml/__tests__/__snapshots__/highlight.test.js.snap
+++ b/server/wrappers/jml/__tests__/__snapshots__/highlight.test.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`highlights results with a p-value of < 0.05 1`] = `
+Array [
+  Object {
+    "Distance": 0.0616845,
+    "Probability": 0.753123,
+    "seq1": "Emydura tanybaraga [KC755187]",
+    "seq2": "Emydura subglobosa [KC755190]",
+  },
+  Object {
+    "Distance": 0.0711744,
+    "Probability": 0.914043,
+    "seq1": "Emydura tanybaraga [KC755187]",
+    "seq2": "Emydura subglobosa [KC755185]",
+  },
+  Object {
+    "Distance": 0.0130486,
+    "Probability": 0.0214893,
+    "__highlight": true,
+    "seq1": "Emydura tanybaraga [KC755187]",
+    "seq2": "Emydura subglobosa [KC755184]",
+  },
+  Object {
+    "Distance": 0.0154211,
+    "Probability": 0.023988,
+    "__highlight": true,
+    "seq1": "Emydura tanybaraga [KC755186]",
+    "seq2": "Emydura subglobosa [KC755184]",
+  },
+  Object {
+    "Distance": 0.0996441,
+    "Probability": 0.972514,
+    "seq1": "Emydura tanybaraga [KC755186]",
+    "seq2": "Emydura victoriae [KC755188]",
+  },
+  Object {
+    "Distance": 0.0877817,
+    "Probability": 0.884558,
+    "seq1": "Emydura macquarii [KC755183]",
+    "seq2": "Emydura subglobosa [KC755190]",
+  },
+  Object {
+    "Distance": 0.0438909,
+    "Probability": 0.73913,
+    "seq1": "Emydura macquarii [KC755183]",
+    "seq2": "Emydura victoriae [KC755189]",
+  },
+]
+`;

--- a/server/wrappers/jml/__tests__/highlight.test.js
+++ b/server/wrappers/jml/__tests__/highlight.test.js
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+
+const { highlightSignificantResults } = require('../highlight')
+
+test('highlights results with a p-value of < 0.05', () => {
+	let input = [
+		{
+			seq1: 'Emydura tanybaraga [KC755187]',
+			seq2: 'Emydura subglobosa [KC755190]',
+			Distance: 0.0616845,
+			Probability: 0.753123,
+		},
+		{
+			seq1: 'Emydura tanybaraga [KC755187]',
+			seq2: 'Emydura subglobosa [KC755185]',
+			Distance: 0.0711744,
+			Probability: 0.914043,
+		},
+		{
+			seq1: 'Emydura tanybaraga [KC755187]',
+			seq2: 'Emydura subglobosa [KC755184]',
+			Distance: 0.0130486,
+			Probability: 0.0214893,
+		},
+		{
+			seq1: 'Emydura tanybaraga [KC755186]',
+			seq2: 'Emydura subglobosa [KC755184]',
+			Distance: 0.0154211,
+			Probability: 0.023988,
+		},
+		{
+			seq1: 'Emydura tanybaraga [KC755186]',
+			seq2: 'Emydura victoriae [KC755188]',
+			Distance: 0.0996441,
+			Probability: 0.972514,
+		},
+		{
+			seq1: 'Emydura macquarii [KC755183]',
+			seq2: 'Emydura subglobosa [KC755190]',
+			Distance: 0.0877817,
+			Probability: 0.884558,
+		},
+		{
+			seq1: 'Emydura macquarii [KC755183]',
+			seq2: 'Emydura victoriae [KC755189]',
+			Distance: 0.0438909,
+			Probability: 0.73913,
+		},
+	]
+
+	let output = input.map(highlightSignificantResults)
+
+	expect(output).toMatchSnapshot()
+
+	// there should be two entries in the input with a __highlight flag
+	expect(output.filter(x => x.__highlight)).toHaveLength(2)
+})

--- a/server/wrappers/jml/highlight.js
+++ b/server/wrappers/jml/highlight.js
@@ -1,0 +1,7 @@
+module.exports.highlightSignificantResults = highlightSignificantResults
+function highlightSignificantResults(item) {
+	if (item.Probability < 0.05) {
+		return { ...item, __highlight: true }
+	}
+	return item
+}

--- a/server/wrappers/jml/index.js
+++ b/server/wrappers/jml/index.js
@@ -4,6 +4,8 @@ const execa = require('execa')
 const tempy = require('tempy')
 const path = require('path')
 const fs = require('fs')
+const fromPairs = require('lodash/fromPairs')
+const toPairs = require('lodash/toPairs')
 const generateControlFile = require('./ctl')
 const { highlightSignificantResults } = require('./highlight')
 const revertHashedIdentifiers = require('./revert-hashed-identifiers')
@@ -76,5 +78,12 @@ async function jml({ phylipData, trees, phylipMapping }) {
 	})
 
 	resObj = resObj.map(highlightSignificantResults)
+
+	// remove the 'Sp Comparison' key from jml results, since it's duplicated
+	// in the seq1/seq2 columns
+	resObj = resObj.map(item =>
+		fromPairs(toPairs(item).filter(([key]) => key !== 'Sp Comparison'))
+	)
+
 	return { distributions: distObj, probabilities: probObj, results: resObj }
 }

--- a/server/wrappers/jml/index.js
+++ b/server/wrappers/jml/index.js
@@ -5,6 +5,7 @@ const tempy = require('tempy')
 const path = require('path')
 const fs = require('fs')
 const generateControlFile = require('./ctl')
+const { highlightSignificantResults } = require('./highlight')
 const revertHashedIdentifiers = require('./revert-hashed-identifiers')
 
 const readFileOr = (filepath, orValue) => {
@@ -74,5 +75,6 @@ async function jml({ phylipData, trees, phylipMapping }) {
 		phylipMapping,
 	})
 
+	resObj = resObj.map(highlightSignificantResults)
 	return { distributions: distObj, probabilities: probObj, results: resObj }
 }


### PR DESCRIPTION
Closes #165 

- <details><summary>Removes the 'Sp Comparison' column from JML's Results table, since it's duplicated in the seq1/seq2 columns</summary>

    <img width="450" alt="screen shot 2018-05-21 at 10 31 43 am" src="https://user-images.githubusercontent.com/464441/40315904-55bfc5e2-5ce2-11e8-8dac-d99184cbe128.png">
    </details>

- Moves "significant result" highlighting (p-value < 0.05) to the server

- Extracts any JML result row that (1) is highlighted and (2) includes some item from the Ent nonmonophyly list of accession numbers

<img alt="screen shot 2018-05-21 at 10 31 46 am" src="https://user-images.githubusercontent.com/464441/40323698-d523fda8-5cfb-11e8-869b-dadd0cc6bb27.png">
