### PR TITLE
Add job resumption support

### DIFF
--- a/electron/index.css
+++ b/electron/index.css
@@ -175,10 +175,16 @@ button {
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
-input[type='submit']:hover,
-button:hover,
-input[type='submit']:active,
-button:active {
+input[type='submit'][disabled],
+button[disabled] {
+	background-color: var(--medium-gray);
+	box-shadow: none;
+}
+
+input[type='submit']:not([disabled]):hover,
+button:not([disabled]):hover,
+input[type='submit']:not([disabled]):active,
+button:not([disabled]):active {
 	cursor: pointer;
 	background-color: var(--teal);
 	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);

--- a/electron/index.css
+++ b/electron/index.css
@@ -33,6 +33,10 @@ pre {
 	font-family: Consolas, Menlo, monospace;
 }
 
+[hidden] {
+	display: none !important;
+}
+
 section {
 	background: var(--white);
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
@@ -296,9 +300,6 @@ summary > h3 {
 	margin-bottom: 2em;
 }
 
-.job {
-}
-
 .job + .job {
 	margin-top: 1em;
 }
@@ -320,7 +321,7 @@ summary > h3 {
 	margin-top: 1em;
 }
 
-.row {
+.flex-row {
 	display: flex;
 	flex-flow: row nowrap;
 }

--- a/electron/index.css
+++ b/electron/index.css
@@ -289,3 +289,15 @@ summary > h3 {
 .row {
 	margin-bottom: 2em;
 }
+
+.job {
+	cursor: pointer;
+}
+
+.job + .job {
+	margin-top: 1em;
+}
+
+.job:nth-child(even) {
+	background-color: var(--light-gray);
+}

--- a/electron/index.css
+++ b/electron/index.css
@@ -297,7 +297,6 @@ summary > h3 {
 }
 
 .job {
-	cursor: pointer;
 }
 
 .job + .job {
@@ -306,4 +305,22 @@ summary > h3 {
 
 .job:nth-child(even) {
 	background-color: var(--light-gray);
+}
+
+.job .info {
+	flex: 1;
+}
+
+.job .buttons {
+	display: flex;
+	flex-flow: column nowrap;
+}
+
+.job .buttons button + button {
+	margin-top: 1em;
+}
+
+.row {
+	display: flex;
+	flex-flow: row nowrap;
 }

--- a/electron/index.html
+++ b/electron/index.html
@@ -42,6 +42,13 @@
 			</div>
 		</section>
 
+		<section id="existing-jobs">
+			<h2>Active Jobs</h2>
+			<ul class="active-jobs-list"><li>No active jobs</li></ul>
+			<h2>Inactive Jobs</h2>
+			<ul class="inactive-jobs-list"><li>No inactive jobs</li></ul>
+		</section>
+
 		<section id="newick-input">
 			<details>
 				<summary><h2>Use a Newick Tree</h2></summary>

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
     "@types/node": {
       "version": "8.10.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
@@ -338,6 +343,27 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+        }
+      }
+    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -407,6 +433,14 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -546,8 +580,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crc": {
       "version": "3.5.0",
@@ -695,8 +728,15 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "deep-extend": {
       "version": "0.5.1",
@@ -721,6 +761,28 @@
       "resolved": "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz",
       "integrity": "sha1-WiBc48Ky73e2I41roXnrdMag6Bg=",
       "dev": true
+    },
+    "dns-packet": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "requires": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "dns-socket": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-1.6.3.tgz",
+      "integrity": "sha512-/mUy3VGqIP69dAZjh2xxHXcpK9wk2Len1Dxz8mWAdrIgFC8tnR/aQAyU4a+UTXzOcTvEvGBdp1zFiwnpWKaXng==",
+      "requires": {
+        "dns-packet": "^1.1.0"
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -989,6 +1051,44 @@
         "mime-types": "^2.1.12"
       }
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "fs-extra": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -1052,6 +1152,11 @@
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -1086,6 +1191,37 @@
         "minimatch": "~3.0.2"
       }
     },
+    "got": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
+      "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
+      "requires": {
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.4.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -1112,6 +1248,19 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
     },
     "hawk": {
       "version": "6.0.2",
@@ -1142,6 +1291,11 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
+    },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1182,8 +1336,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -1246,6 +1399,25 @@
         }
       }
     },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
+      }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
     "irregular-plurals": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
@@ -1284,11 +1456,34 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
+      "requires": {
+        "ip-regex": "^2.0.0"
+      }
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1314,6 +1509,15 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
+    },
     "js-yaml": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
@@ -1329,6 +1533,11 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1367,6 +1576,14 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "requires": {
+        "json-buffer": "3.0.0"
       }
     },
     "klaw": {
@@ -1461,6 +1678,11 @@
         "signal-exit": "^3.0.0"
       }
     },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -1505,6 +1727,11 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1570,6 +1797,26 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "requires": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        }
+      }
+    },
     "normalize.css": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.0.tgz",
@@ -1611,8 +1858,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-keys": {
       "version": "0.4.0",
@@ -1661,6 +1907,29 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "p-cancelable": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
@@ -1743,6 +2012,11 @@
         "irregular-plurals": "^1.0.0"
       }
     },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+    },
     "pretty-bytes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
@@ -1765,8 +2039,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress-stream": {
       "version": "1.2.0",
@@ -1776,6 +2049,24 @@
       "requires": {
         "speedometer": "~0.1.2",
         "through2": "~0.2.3"
+      }
+    },
+    "public-ip": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/public-ip/-/public-ip-2.4.0.tgz",
+      "integrity": "sha512-74cIy+T2cDmt+Z71AfVipH2q6qqZITPyNGszKV86OGDYIRvti1m8zg4GOaiTPCLgEIWnToKYXbhEnMiZWHPEUA==",
+      "requires": {
+        "dns-socket": "^1.6.2",
+        "got": "^8.0.0",
+        "is-ip": "^2.0.0",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "punycode": {
@@ -1795,6 +2086,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -1914,6 +2215,14 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -1966,8 +2275,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sax": {
       "version": "1.2.4",
@@ -2115,6 +2423,11 @@
         "jsbn": "~0.1.0",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
       "version": "1.0.2",
@@ -2271,6 +2584,11 @@
         "xtend": "~2.1.1"
       }
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -2346,11 +2664,23 @@
         }
       }
     },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.2.1",

--- a/electron/package.json
+++ b/electron/package.json
@@ -67,7 +67,8 @@
     "lodash": "^4.17.10",
     "loud-rejection": "^1.6.0",
     "normalize.css": "^8.0.0",
-    "pretty-ms": "^3.1.0"
+    "pretty-ms": "^3.1.0",
+    "public-ip": "^2.4.0"
   },
   "devDependencies": {
     "electron": "^2.0.0",

--- a/electron/run.js
+++ b/electron/run.js
@@ -25,6 +25,7 @@ function run() {
 
 	// hide the input boxes
 	document.querySelector('#file-input').hidden = true
+	document.querySelector('#existing-jobs').hidden = true
 	document.querySelector('#newick-input').hidden = true
 
 	// get the chosen pipeline name

--- a/electron/run.js
+++ b/electron/run.js
@@ -3,6 +3,7 @@
 const { load, setEntResults } = require('./graph')
 const makeTableFromObjectList = require('./lib/html-table')
 const prettyMs = require('pretty-ms')
+const publicIp = require('public-ip')
 const fs = require('fs')
 const fromPairs = require('lodash/fromPairs')
 
@@ -43,7 +44,7 @@ function run() {
 	return false
 }
 
-function submitJob({
+async function submitJob({
 	socket = global.socket,
 	pipeline,
 	filepath,
@@ -51,6 +52,7 @@ function submitJob({
 	options,
 }) {
 	const ws = socket
+	const ip = (await publicIp.v6()) || (await publicIp.v4())
 
 	ws.addEventListener('message', packet => onMessage(packet.data))
 	ws.addEventListener('disconnect', (...args) =>
@@ -63,7 +65,14 @@ function submitJob({
 		throw new Error('socket not ready!')
 	}
 
-	let payload = { type: 'start', pipeline, filepath, data, options }
+	let payload = {
+		type: 'start-pipeline',
+		pipeline,
+		filepath,
+		data,
+		options,
+		ip,
+	}
 	ws.send(JSON.stringify(payload), err => {
 		if (err) {
 			console.error('server error', err)

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -155,8 +155,10 @@ function populatePipelinePicker(pipelines, baseUrl) {
 	)
 }
 
-const cancelJob = (id, baseUrl) => fetchJson(baseUrl + `job/${id}`, {method: 'DELETE'})
-const restartJob = (id, baseUrl) => fetchJson(baseUrl + `job/${id}`, {method: 'POST'})
+const cancelJob = (id, baseUrl) =>
+	fetchJson(baseUrl + `job/${id}`, { method: 'DELETE' })
+const restartJob = (id, baseUrl) =>
+	fetchJson(baseUrl + `job/${id}`, { method: 'POST' })
 
 function populateJobList(jobs, baseUrl) {
 	let jobsContainer = document.querySelector('#existing-jobs')

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -174,7 +174,7 @@ function populateJobList(jobs, baseUrl) {
 	}) => {
 		let li = document.createElement('li')
 		li.classList.add('job')
-		li.classList.add('row')
+		li.classList.add('flex-row')
 
 		li.innerHTML = `
 			<div class="info">

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -24,11 +24,13 @@ function updateWebSocket(newUri) {
 
 function initWebsocket() {
 	global.socket.addEventListener('open', connectionIsUp)
+	global.socket.addEventListener('close', connectionClosed)
 	global.socket.addEventListener('error', connectionRefused)
 }
 
 function destroyWebsocket() {
 	global.socket.removeEventListener('open', connectionIsUp)
+	global.socket.removeEventListener('close', connectionClosed)
 	global.socket.removeEventListener('error', connectionRefused)
 	global.socket.close()
 }
@@ -85,6 +87,16 @@ function connectionRefused() {
 
 	// TODO: rework connectionIsUp/connectionRefused to remove the
 	// event listeners when the socket changes
+}
+
+function connectionClosed() {
+	document.querySelector('#server-status').classList.remove('up')
+	document.querySelector('#server-status').classList.add('down')
+
+	Array.from(document.querySelectorAll('.checkmark.active')).forEach(node => {
+		node.classList.remove('active')
+		node.classList.add('error')
+	})
 }
 
 function populateFilePicker(files) {

--- a/electron/ui.js
+++ b/electron/ui.js
@@ -183,7 +183,7 @@ function populateJobList(jobs, baseUrl) {
 					<tr><th>Filename</th><td>${filename}</td></tr>
 					<tr><th>Status</th><td>${status}</td></tr>
 					<tr><th>ID</th><td>${id}</td></tr>
-					<tr><th>Options</th><td>${JSON.stringify(options)}</td></tr>
+					<tr><th>Options</th><td>${JSON.stringify(options, null, 2)}</td></tr>
 					${duration ? `<tr><th>Duration</th><td>${prettyMs(duration)}</td></tr>` : ''}
 					<tr><th>Started by</th><td>${initialClientAddress}</td></tr>
 				</table>

--- a/server/job.js
+++ b/server/job.js
@@ -1,0 +1,109 @@
+'use strict'
+
+const childProcess = require('child_process')
+const path = require('path')
+const hasha = require('hasha')
+const hashObj = require('hash-obj')
+const { trimMessage } = require('./lib/trim-message')
+
+const workerPath = path.join(__dirname, 'pipeline', 'worker.js')
+
+class Job {
+	constructor({ pipeline, data, filepath, options = {}, ip }) {
+		this.status = 'inactive'
+		this.clients = new Set()
+		this.workerMessages = []
+		this.startTime = null
+		this.endTime = null
+		this.duration = 0
+
+		this.pipeline = pipeline
+		this.data = data
+		this.options = options
+		this.dataHash = hasha(data)
+		this.optionsHash = hashObj(options)
+		this.hash = hasha([this.dataHash, this.optionsHash])
+		this.filepath = filepath
+		this.id = this.hash
+		this.initialClientAddress = ip
+
+		this.addClient = this.addClient.bind(this)
+		this.removeClient = this.removeClient.bind(this)
+		this.complete = this.complete.bind(this)
+		this.handleClientMessage = this.handleClientMessage.bind(this)
+		this.handleWorkerMessage = this.handleWorkerMessage.bind(this)
+		this.broadcast = this.broadcast.bind(this)
+
+		this.child = childProcess.fork(workerPath)
+		this.child.on('message', this.handleWorkerMessage)
+	}
+
+	addClient(socket, ip) {
+		socket.__ip = ip
+		console.log('added client', ip)
+
+		socket.on('message', this.handleClientMessage)
+		socket.on('close', () => this.removeClient(socket))
+
+		this.clients.add(socket)
+		this.workerMessages.forEach(serialized => socket.send(serialized))
+	}
+
+	removeClient(socket) {
+		console.log('removed client', socket.__ip)
+		this.clients.delete(socket)
+	}
+
+	handleClientMessage(msg) {
+		switch (msg.type) {
+			case 'follow-pipeline': {
+				break
+			}
+			case 'start-pipeline': {
+				this.status = 'active'
+				this.startTime = Date.now()
+				this.child.send(msg)
+				break
+			}
+			default: {
+				this.child.send(msg)
+			}
+		}
+	}
+
+	handleWorkerMessage(msg) {
+		console.log(trimMessage(msg))
+
+		let serialized = JSON.stringify(msg)
+		this.workerMessages.push(serialized)
+		this.broadcast(serialized)
+
+		if (msg.type === 'exit' || msg.type === 'error') {
+			this.complete()
+		}
+	}
+
+	complete() {
+		if (this.child.connected) {
+			this.child.disconnect()
+		}
+		this.status = 'completed'
+		this.endTime = Date.now()
+		this.duration = this.endTime - this.startTime
+	}
+
+	stop() {
+		if (this.child.connected) {
+			this.child.disconnect()
+		}
+		this.status = 'stopped'
+		this.endTime = Date.now()
+		this.duration = this.endTime - this.startTime
+	}
+
+	broadcast(serialized) {
+		this.clients.forEach(socket => socket.send(serialized))
+	}
+}
+
+module.exports = Job

--- a/server/job.js
+++ b/server/job.js
@@ -24,7 +24,7 @@ class Job {
 		this.optionsHash = hashObj(options)
 		this.hash = hasha([this.dataHash, this.optionsHash])
 		this.filepath = filepath
-		this.id = this.hash
+		this.id = this.hash.substr(0, 32)
 		this.initialClientAddress = ip
 
 		this.addClient = this.addClient.bind(this)

--- a/server/lib/trim-message.js
+++ b/server/lib/trim-message.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports.trimMessage = trimMessage
+function trimMessage(message) {
+	return JSON.parse(
+		JSON.stringify(message, (k, v) => {
+			if (typeof v === 'string' && v.length > 99) {
+				return v.substr(0, 99) + '…'
+			}
+			return v
+		})
+	)
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -322,6 +322,15 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "optional": true
     },
+    "hash-obj": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hash-obj/-/hash-obj-1.0.0.tgz",
+      "integrity": "sha1-3lP5hWsW8edvauBNT50xwxqq6gA=",
+      "requires": {
+        "is-obj": "^1.0.0",
+        "sort-keys": "^1.1.0"
+      }
+    },
     "hasha": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
@@ -378,6 +387,16 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
       "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw=="
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -869,6 +888,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash-escape/-/slash-escape-1.0.0.tgz",
       "integrity": "sha1-EE1+9Py1JmACZnGveaUefMZ8p80="
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
     },
     "statuses": {
       "version": "1.5.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -322,6 +322,14 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "optional": true
     },
+    "hasha": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "requires": {
+        "is-stream": "^1.0.1"
+      }
+    },
     "http-assert": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -36,6 +36,7 @@
     "dedent": "^0.7.0",
     "execa": "^0.10.0",
     "get-stdin": "^6.0.0",
+    "hasha": "^3.0.0",
     "koa": "^2.5.1",
     "koa-compress": "^3.0.0",
     "koa-logger": "^3.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -36,6 +36,7 @@
     "dedent": "^0.7.0",
     "execa": "^0.10.0",
     "get-stdin": "^6.0.0",
+    "hash-obj": "^1.0.0",
     "hasha": "^3.0.0",
     "koa": "^2.5.1",
     "koa-compress": "^3.0.0",

--- a/server/pipeline/cache.js
+++ b/server/pipeline/cache.js
@@ -19,7 +19,6 @@ class Cache {
 
 		this.get = this.get.bind(this)
 		this.set = this.set.bind(this)
-		this.hash = this.hash.bind(this)
 		this.diskFilename = this.diskFilename.bind(this)
 
 		let cacheRoot = process.env.DOCKER ? `/tmp/hybsearch` : tempy.directory()

--- a/server/pipeline/cache.js
+++ b/server/pipeline/cache.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const crypto = require('crypto')
 const hasha = require('hasha')
 const tempy = require('tempy')
 const fs = require('fs')

--- a/server/pipeline/cache.js
+++ b/server/pipeline/cache.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const crypto = require('crypto')
+const hasha = require('hasha')
 const tempy = require('tempy')
 const fs = require('fs')
 const path = require('path')
@@ -14,10 +15,8 @@ class Cache {
 		this.pipelineName = pipelineName
 		this.options = options
 
-		this.hashKey = this.hash(
-			`${this.pipelineName}${JSON.stringify(this.options)}`
-		)
-		this.dataHash = this.hash(`${this.hashKey}:${this.data}`)
+		this.hashKey = hasha(`${this.pipelineName}${JSON.stringify(this.options)}`)
+		this.dataHash = hasha(`${this.hashKey}:${this.data}`)
 
 		this.get = this.get.bind(this)
 		this.set = this.set.bind(this)
@@ -28,12 +27,6 @@ class Cache {
 		this.cacheDir = mkdir.sync(`${cacheRoot}/${this.dataHash}`)
 
 		this.set('source', { filepath: this.filepath, contents: this.data })
-	}
-
-	hash(data) {
-		let hash = crypto.createHash('sha256')
-		hash.update(data)
-		return hash.digest('hex')
 	}
 
 	diskFilename(filename) {

--- a/server/server.js
+++ b/server/server.js
@@ -50,6 +50,20 @@ router.get('/file/:name', async ctx => {
 	ctx.body = { content: await loadFile(ctx.params.name) }
 })
 
+router.get('/jobs', async ctx => {
+	ctx.body = {
+		jobs: [...workers.values()].reverse().map(worker => ({
+			pipeline: worker.pipeline,
+			filename: path.basename(worker.filepath),
+			id: worker.id,
+			hash: worker.hash,
+			options: worker.options,
+			status: worker.status,
+			initialClientAddress: worker.initialClientAddress,
+		})),
+	}
+})
+
 router.get('/uptime', ctx => {
 	ctx.body = { uptime: Date.now() - STARTED }
 })

--- a/server/server.js
+++ b/server/server.js
@@ -69,7 +69,7 @@ router.delete('/job/:id', async ctx => {
 	let worker = workers.get(ctx.params.id)
 	if (worker) {
 		worker.stop()
-		ctx.body = {stopped: true, id: worker.id}
+		ctx.body = { stopped: true, id: worker.id }
 	} else {
 		ctx.throw(500, 'no worker found')
 	}
@@ -79,7 +79,7 @@ router.post('/job/:id', async ctx => {
 	let worker = workers.get(ctx.params.id)
 	if (worker) {
 		worker.restart()
-		ctx.body = {started: true, id: worker.id}
+		ctx.body = { started: true, id: worker.id }
 	} else {
 		ctx.throw(500, 'no worker found')
 	}

--- a/server/server.js
+++ b/server/server.js
@@ -14,7 +14,7 @@ const { trimMessage } = require('./lib/trim-message')
 const getFiles = require('./lib/get-files')
 const { loadFile } = getFiles
 
-const PORT = 8080
+const PORT = parseInt(process.env.PORT, 10) || 8080
 const app = new Koa()
 const server = http.createServer(app.callback())
 const wss = new WebSocket.Server({

--- a/server/server.js
+++ b/server/server.js
@@ -60,6 +60,7 @@ router.get('/jobs', async ctx => {
 			options: worker.options,
 			status: worker.status,
 			initialClientAddress: worker.initialClientAddress,
+			duration: worker.duration,
 		})),
 	}
 })

--- a/server/server.js
+++ b/server/server.js
@@ -64,6 +64,16 @@ router.get('/jobs', async ctx => {
 	}
 })
 
+router.delete('/job/:id', async ctx => {
+	let worker = workers.get(ctx.params.id)
+	if (worker) {
+		worker.stop()
+		ctx.body = {stopped: true, id: worker.id}
+	} else {
+		ctx.throw(500, 'no worker found')
+	}
+})
+
 router.get('/uptime', ctx => {
 	ctx.body = { uptime: Date.now() - STARTED }
 })

--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,7 @@ const Koa = require('koa')
 const Router = require('koa-router')
 const compress = require('koa-compress')
 const logger = require('koa-logger')
+const { trimMessage } = require('./lib/trim-message')
 const getFiles = require('./lib/get-files')
 const { loadFile } = getFiles
 
@@ -59,17 +60,6 @@ app.use(router.routes())
 app.use(router.allowedMethods())
 
 const workerPath = path.join(__dirname, 'pipeline', 'worker.js')
-
-function trimMessage(message) {
-	return JSON.parse(
-		JSON.stringify(message, (k, v) => {
-			if (typeof v === 'string' && v.length > 99) {
-				return v.substr(0, 99) + '…'
-			}
-			return v
-		})
-	)
-}
 
 // listen for new websocket connections
 wss.on('connection', ws => {

--- a/server/server.js
+++ b/server/server.js
@@ -75,6 +75,16 @@ router.delete('/job/:id', async ctx => {
 	}
 })
 
+router.post('/job/:id', async ctx => {
+	let worker = workers.get(ctx.params.id)
+	if (worker) {
+		worker.restart()
+		ctx.body = {started: true, id: worker.id}
+	} else {
+		ctx.throw(500, 'no worker found')
+	}
+})
+
 router.get('/uptime', ctx => {
 	ctx.body = { uptime: Date.now() - STARTED }
 })


### PR DESCRIPTION
This PR separates the client connections from the running worker processes, allowing us several useful features:

- You can now close the client app, and the worker will continue running
- You can now "follow" an existing job, which will send you all of the events just like they're sent to the original client
- You can now cancel (or restart cancelled) jobs

<img width="900" alt="screen shot 2018-05-21 at 6 52 00 pm" src="https://user-images.githubusercontent.com/464441/40335201-1688827e-5d28-11e8-9e34-5c6bf6677c0e.png">
