### PR TITLE
Set outlierRemovalPercentage to apply to the proper spot

### DIFF
--- a/server/lib/prune-newick.js
+++ b/server/lib/prune-newick.js
@@ -12,7 +12,7 @@ module.exports.removeNodes = removeNodes
 function pruneOutliers(
 	newick,
 	alignedFasta,
-	{ outlierRemovalPercentage = 0.5 } = {}
+	{ outlierRemovalPercentage = 0.2 } = {}
 ) {
 	const fastaData = parseFasta(alignedFasta)
 	// Build a dict map of species -> sequence
@@ -91,7 +91,7 @@ function pruneOutliers(
 			let smallerGeneLength = Math.min(gene1Length, gene2Length)
 			let diffProportion = hammingDistance / smallerGeneLength
 
-			if (diffProportion > 0.2) {
+			if (diffProportion > outlierRemovalPercentage) {
 				diffCount += 1
 			}
 		}
@@ -99,7 +99,7 @@ function pruneOutliers(
 		let diffPercent = diffCount / (leafNodes.length - 1)
 
 		if (
-			diffPercent >= outlierRemovalPercentage ||
+			diffPercent >= 0.5 ||
 			gene1Length < SEQUENCE_CUTOFF_LENGTH
 		) {
 			if (node.ident) {

--- a/server/lib/prune-newick.js
+++ b/server/lib/prune-newick.js
@@ -98,10 +98,7 @@ function pruneOutliers(
 
 		let diffPercent = diffCount / (leafNodes.length - 1)
 
-		if (
-			diffPercent >= 0.5 ||
-			gene1Length < SEQUENCE_CUTOFF_LENGTH
-		) {
+		if (diffPercent >= 0.5 || gene1Length < SEQUENCE_CUTOFF_LENGTH) {
 			if (node.ident) {
 				toRemoveNames.push(node.ident)
 			} else {

--- a/server/pipeline/pipelines/mbnb.js
+++ b/server/pipeline/pipelines/mbnb.js
@@ -24,7 +24,7 @@ const { removeCircularLinks } = require('../lib')
 
 let options = {
 	outlierRemovalPercentage: {
-		default: 0.5,
+		default: 0.2,
 		type: 'number',
 		label: 'outlierRemovalPercentage',
 		description: 'desc',


### PR DESCRIPTION
@OmarShehata:

> The other one should be at a constant 0.5. That's my bad. It's 0.5 because we're saying if you're differnt from the majority, you're an outlier
>
> what is interesting is how different a given _gene_ sequence is
>
> That's why I was confusing how you were reporting those numbers for each species. because diff proportion is comparison value, not an absolute value
>
> …like, pairwise comparison
>
> This will be invaluable for researchers to see when something goes wrong, but most of the time will be just noise