### PR TITLE
Starting some Ent cleanups

### DIFF
--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -3,6 +3,7 @@
 const combs = require('combinations-generator')
 const uniqBy = require('lodash/uniqBy')
 const countBy = require('lodash/countBy')
+const groupBy = require('lodash/groupBy')
 const remove = require('lodash/remove')
 const { removeNodes } = require('../lib/prune-newick')
 const { parseFasta } = require('../formats/fasta/parse')
@@ -139,16 +140,8 @@ function isSpeciesMonophyletic(rootNode, speciesName) {
 // We only want hybrids that, once removed, make their species monophyletic
 // Check if all the flagged ones have this property. Otherwise unflag them
 function unflagIfRemovingDoesNotFix(results, rootNode) {
-	let hybridSpeciesByName = {}
-	let totalHybridSpecies = 0
-	for (let hybrid of results.nm) {
-		let speciesName = hybrid.name
-		if (hybridSpeciesByName[speciesName] === undefined) {
-			hybridSpeciesByName[speciesName] = []
-			totalHybridSpecies += 1
-		}
-		hybridSpeciesByName[speciesName].push(hybrid)
-	}
+	let hybridSpeciesByName = groupBy(results.nm, hybrid => hybrid.name)
+	let totalHybridSpecies = Object.keys(hybridSpeciesByName).length
 
 	// For each species found (if at least 2)
 	if (totalHybridSpecies > 1) {

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -6,6 +6,7 @@ const countBy = require('lodash/countBy')
 const groupBy = require('lodash/groupBy')
 const remove = require('lodash/remove')
 const { removeNodes } = require('../lib/prune-newick')
+const { getLeafNodes } = require('../lib/get-leaf-nodes')
 const { parseFasta } = require('../formats/fasta/parse')
 const hammingDistance = require('../hamdis/hamming-distance')
 
@@ -120,15 +121,7 @@ function isSpeciesMonophyletic(rootNode, speciesName) {
 	let MCRA = getMostRecentCommonAncestor(rootNode, speciesName)
 
 	// Determine whether everything under that node is of the same species
-	let leafNodes = []
-	const getLeafNodes = node => {
-		if (node.branchset) {
-			node.branchset.forEach(getLeafNodes)
-		} else {
-			leafNodes.push(node)
-		}
-	}
-	getLeafNodes(MCRA)
+	let leafNodes = getLeafNodes(MCRA)
 
 	let allEqual = leafNodes.every(n => n.name === speciesName)
 	return allEqual

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -2,6 +2,7 @@
 
 const combs = require('combinations-generator')
 const uniqBy = require('lodash/uniqBy')
+const countBy = require('lodash/countBy')
 const remove = require('lodash/remove')
 const { removeNodes } = require('../lib/prune-newick')
 const { parseFasta } = require('../formats/fasta/parse')
@@ -202,25 +203,12 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 	}
 
 	getAllIndividuals(rootNode)
+
 	// Count number of hybrids for each species
-	let hybridSpeciesCount = {}
-	for (let hybrid of results.nm) {
-		let speciesName = hybrid.name
-		if (hybridSpeciesCount[speciesName] === undefined) {
-			hybridSpeciesCount[speciesName] = 0
-		}
-		hybridSpeciesCount[speciesName] += 1
-	}
+	let hybridSpeciesCount = countBy(results.nm, hybrid => hybrid.name)
 
 	// Count number of individuals in each species
-	let totalSpeciesCount = {}
-	for (let individual of allIndividuals) {
-		let speciesName = individual.name
-		if (totalSpeciesCount[speciesName] === undefined) {
-			totalSpeciesCount[speciesName] = 0
-		}
-		totalSpeciesCount[speciesName] += 1
-	}
+	let totalSpeciesCount = countBy(allIndividuals, individual => individual.name)
 
 	for (let speciesName in hybridSpeciesCount) {
 		// If we've flagged every individual in this species

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -76,21 +76,6 @@ function getMostRecentCommonAncestor(rootNode, speciesName) {
 	addParent(rootCopy)
 
 	// Find just one individual of the species
-	function findIndividualsOfSpecies(startNode, targetSpeciesName) {
-		let allIndividuals = []
-		function find(node) {
-			if (node.branchset) {
-				node.branchset.forEach(find)
-			} else {
-				if (node.name === targetSpeciesName) {
-					allIndividuals.push(node)
-				}
-			}
-		}
-		find(startNode)
-		return allIndividuals
-	}
-
 	let allIndividuals = findIndividualsOfSpecies(rootCopy, speciesName)
 
 	if (allIndividuals.length === 0) {
@@ -111,6 +96,10 @@ function getMostRecentCommonAncestor(rootNode, speciesName) {
 		leafNodes = findIndividualsOfSpecies(individual, speciesName)
 	}
 	return individual
+}
+
+function findIndividualsOfSpecies(rootNode, speciesName) {
+	return getLeafNodes(rootNode).filter(node => node.name === speciesName)
 }
 
 // Given a species and a tree, will return true if all individuals
@@ -175,17 +164,7 @@ function getSmallestInterSpeciesDistance(individual, sequenceMap) {
 
 // Check if we've flagged the entire species. If so, start unflagging
 function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
-	let allIndividuals = []
-
-	function getAllIndividuals(node) {
-		if (!node.branchset) {
-			allIndividuals.push(node)
-		} else {
-			node.branchset.forEach(getAllIndividuals)
-		}
-	}
-
-	getAllIndividuals(rootNode)
+	let allIndividuals = getLeafNodes(rootNode)
 
 	// Count number of hybrids for each species
 	let hybridSpeciesCount = countBy(results.nm, hybrid => hybrid.name)

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -9,9 +9,6 @@ const { removeNodes } = require('../lib/prune-newick')
 const { parseFasta } = require('../formats/fasta/parse')
 const hammingDistance = require('../hamdis/hamming-distance')
 
-const ENABLE_DEBUG = false
-let debug = ENABLE_DEBUG ? console.log.bind(console) : () => {}
-
 let label = node => `${node.name} (${node.ident})`
 const LABEL_DIVIDER = '__'
 const makeIdent = node => node.name + LABEL_DIVIDER + node.ident
@@ -262,7 +259,6 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 // and `nm` is a list of flagged hybrids
 function recursiveSearch(node, nmInstances = []) {
 	if (node.branchset) {
-		debug('has branchset')
 		let combinations = combs(node.branchset, 2)
 
 		let speciesList = []
@@ -275,14 +271,11 @@ function recursiveSearch(node, nmInstances = []) {
 			let resultsB = recursiveSearch(speciesSet[0], nmInstances)
 			let speciesListB = resultsB.species
 
-			debug('speciesListA:', speciesListA, 'speciesListB', speciesListB)
-
 			const speciesChecker = otherSpeciesList => species1 => {
 				const otherSpeciesNames = otherSpeciesList.map(s => s.name)
 
 				let hasName = otherSpeciesNames.includes(species1.name)
 				let notAllEqual = !otherSpeciesNames.every(n => n === species1.name)
-				debug(`included: ${hasName}; not all equal: ${notAllEqual}`)
 
 				if (hasName && notAllEqual) {
 					otherSpeciesList.forEach(species3 => {
@@ -290,13 +283,8 @@ function recursiveSearch(node, nmInstances = []) {
 							const count = nmInstances.filter(sp => sp === species3).length
 
 							if (!count) {
-								debug(`nmMark called on ${species3}`)
-								debug(`nonmonophyly: ${label(species3)}`)
-
 								nmInstances.push(species3)
-
 								forRemoval.push(species3.ident)
-								debug(`removing from A ${label(species3)}`)
 							}
 						}
 					})
@@ -319,11 +307,9 @@ function recursiveSearch(node, nmInstances = []) {
 
 		speciesList = uniqBy(speciesList, 'ident')
 
-		debug('speciesList', speciesList)
 		return { species: speciesList, nm: nmInstances }
 	}
 
-	debug(`no branchset, name: ${node.name}, ident: ${node.ident}`)
 	return { species: [node], nm: nmInstances }
 }
 

--- a/server/lib/get-leaf-nodes.js
+++ b/server/lib/get-leaf-nodes.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports.getLeafNodes = getLeafNodes
+
+function getLeafNodes(node) {
+	let leafNodes = []
+
+	const recurse = node => {
+		if (node.branchset) {
+			node.branchset.forEach(recurse)
+		} else {
+			leafNodes.push(node)
+		}
+	}
+
+	recurse(node)
+	return leafNodes
+}


### PR DESCRIPTION
- Makes use of `_.countBy` and `_.groupBy` instead of writing iterative loops
- Removes `debug` calls from `recursiveSearch`
- Uses `getLeafNodes` to power `findIndividualsOfSpecies` and `getAllIndividuals`

I'd like to merge this and continue other cleanups in future PRs, or else I'll get carried away like I usually do.