### PR TITLE
Remove linux build from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,6 @@ workflows:
           requires: [lint, test-app]
       - build-app-mac:
           requires: [lint, test-app]
-      - build-app-linux:
-          requires: [lint, test-app]
 
   on_tag:
     jobs:
@@ -78,9 +76,6 @@ workflows:
           requires: [lint, test-server, test-pipeline-mbnb, test-app]
           filters: *filters
       - build-app-mac:
-          requires: [lint, test-server, test-pipeline-mbnb, test-app]
-          filters: *filters
-      - build-app-linux:
           requires: [lint, test-server, test-pipeline-mbnb, test-app]
           filters: *filters
 
@@ -219,14 +214,3 @@ jobs:
       - run: cd electron && npm install --production
       - run: cd electron && npm run build:setup
       - run: cd electron && electron-builder --macos
-
-  build-app-linux:
-    <<: *electron-builder-base
-    steps:
-      - checkout:
-          path: /root/project
-      - run: *install-electron-builder
-      - run: *electron-pkg-version
-      - run: cd electron && npm install --production
-      - run: cd electron && npm run build:setup
-      - run: cd electron && electron-builder --linux


### PR DESCRIPTION
It consistently takes 3+ minutes to build, while macOS and Windows are both around 2min/2.5min.

That's my main reason, followed by the fact that none of us use a Linux GUI, and AFAIK it's never even been tested.

EDIT: With this, combined with the pipeline test changes in #211, we drop from around ~13m to run on Circle to only ~5m!