### PR TITLE
More Ent cleanups

### DIFF
--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -214,11 +214,11 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 			// removed ones are the true hybrids. Everyone else is unflagged
 			let shortestDist
 			let closestHybrid
-			for (let hybrid of results.nm) {
-				if (
-					hybrid.name === speciesName &&
-					!collectedHybridIdents[hybrid.ident]
-				) {
+
+			results.nm
+				.filter(hybrid => hybrid.name === speciesName)
+				.filter(hybrid => !collectedHybridIdents[hybrid.ident])
+				.forEach(hybrid => {
 					let dist = getSmallestInterSpeciesDistance(hybrid, sequenceMap)
 					if (shortestDist === undefined) {
 						shortestDist = dist
@@ -227,8 +227,7 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 						shortestDist = dist
 						closestHybrid = hybrid
 					}
-				}
-			}
+				})
 
 			// The closest one to a different species is probably a hybrid, so
 			// let's not remove it

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -210,11 +210,10 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 
 		while (!isMono) {
 			// We need to remove the one that's closest to a different species
-			// and continue to do this until monophyly is achieved
-			// Those removed ones are the true hybrids. Everyone else is unflagged
+			// and continue to do this until monophyly is achieved. Those
+			// removed ones are the true hybrids. Everyone else is unflagged
 			let shortestDist
 			let closestHybrid
-			//let newResults = recursiveSearch(rootNodeCopy)
 			for (let hybrid of results.nm) {
 				if (
 					hybrid.name === speciesName &&
@@ -231,14 +230,17 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 				}
 			}
 
-			// The closest one to a different species is probably a hybrid so let's not remove it
+			// The closest one to a different species is probably a hybrid, so
+			// let's not remove it
 			if (closestHybrid === undefined) {
 				break
 			}
+
 			collectedHybridIdents[closestHybrid.ident] = true
 			remove(toRemove, ident => ident === closestHybrid.ident)
 			removeNodes(rootNodeCopy, [closestHybrid.ident])
-			// Now check if monophyly is achieved and repeat if not
+
+			// Now check if monophyly is achieved, and repeat if not
 			isMono = isSpeciesMonophyletic(rootNodeCopy, speciesName)
 		}
 

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -191,7 +191,7 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 	// Count number of individuals in each species
 	let totalSpeciesCount = countBy(allIndividuals, individual => individual.name)
 
-	for (let speciesName in hybridSpeciesCount) {
+	for (let speciesName of Object.keys(hybridSpeciesCount)) {
 		// If we've flagged every individual in this species
 		if (hybridSpeciesCount[speciesName] !== totalSpeciesCount[speciesName]) {
 			continue

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -199,13 +199,11 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 		}
 
 		// We initially assume we're going to remove everybody
-		let toRemove = []
 		let collectedHybridIdents = {}
-		for (let hybrid of results.nm) {
-			if (hybrid.name === speciesName) {
-				toRemove.push(hybrid.ident)
-			}
-		}
+		let toRemove = results.nm
+			.filter(hybrid => hybrid.name === speciesName)
+			.map(hybrid => hybrid.ident)
+
 		let rootNodeCopy = JSON.parse(JSON.stringify(rootNode))
 		let isMono = false
 

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -274,16 +274,16 @@ function recursiveSearch(node, nmInstances = []) {
 			let notAllEqual = !otherSpeciesNames.every(n => n === species1.name)
 
 			if (hasName && notAllEqual) {
-				otherSpeciesList.forEach(species3 => {
-					if (species3.name === species1.name) {
+				otherSpeciesList
+					.filter(species3 => species3.name === species1.name)
+					.forEach(species3 => {
 						const count = nmInstances.filter(sp => sp === species3).length
 
 						if (!count) {
 							nmInstances.push(species3)
 							forRemoval.push(species3.ident)
 						}
-					}
-				})
+					})
 			}
 		}
 

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -161,8 +161,8 @@ function unflagIfRemovingDoesNotFix(results, rootNode) {
 	remove(results.nm, hybrid => unflag.includes(hybrid.ident))
 }
 
-// Given an individual, find the shortest distance to an individiual that
-/// is not of the same species
+// Given an individual, find the shortest distance to an individiual that is
+// not of the same species
 function getSmallestInterSpeciesDistance(individual, sequenceMap) {
 	let individualSequence = sequenceMap[makeIdent(individual)]
 	let shortestDist

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -251,59 +251,59 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 // where `species` is a list of individuals under that node
 // and `nm` is a list of flagged hybrids
 function recursiveSearch(node, nmInstances = []) {
-	if (node.branchset) {
-		let combinations = combs(node.branchset, 2)
+	if (!node.branchset) {
+		return { species: [node], nm: nmInstances }
+	}
 
-		let speciesList = []
-		let forRemoval = []
-		for (let speciesSet of combinations) {
-			// if species is in speciesList: continue
-			let resultsA = recursiveSearch(speciesSet[1], nmInstances)
-			let speciesListA = resultsA.species
+	let combinations = combs(node.branchset, 2)
 
-			let resultsB = recursiveSearch(speciesSet[0], nmInstances)
-			let speciesListB = resultsB.species
+	let speciesList = []
+	let forRemoval = []
+	for (let speciesSet of combinations) {
+		// if species is in speciesList: continue
+		let resultsA = recursiveSearch(speciesSet[1], nmInstances)
+		let speciesListA = resultsA.species
 
-			const speciesChecker = otherSpeciesList => species1 => {
-				const otherSpeciesNames = otherSpeciesList.map(s => s.name)
+		let resultsB = recursiveSearch(speciesSet[0], nmInstances)
+		let speciesListB = resultsB.species
 
-				let hasName = otherSpeciesNames.includes(species1.name)
-				let notAllEqual = !otherSpeciesNames.every(n => n === species1.name)
+		const speciesChecker = otherSpeciesList => species1 => {
+			const otherSpeciesNames = otherSpeciesList.map(s => s.name)
 
-				if (hasName && notAllEqual) {
-					otherSpeciesList.forEach(species3 => {
-						if (species3.name === species1.name) {
-							const count = nmInstances.filter(sp => sp === species3).length
+			let hasName = otherSpeciesNames.includes(species1.name)
+			let notAllEqual = !otherSpeciesNames.every(n => n === species1.name)
 
-							if (!count) {
-								nmInstances.push(species3)
-								forRemoval.push(species3.ident)
-							}
+			if (hasName && notAllEqual) {
+				otherSpeciesList.forEach(species3 => {
+					if (species3.name === species1.name) {
+						const count = nmInstances.filter(sp => sp === species3).length
+
+						if (!count) {
+							nmInstances.push(species3)
+							forRemoval.push(species3.ident)
 						}
-					})
-				}
-			}
-
-			speciesListA.forEach(speciesChecker(speciesListB))
-			remove(speciesListA, n => forRemoval.includes(n.ident))
-
-			speciesListB.forEach(speciesChecker(speciesListA))
-			remove(speciesListB, n => forRemoval.includes(n.ident))
-
-			if (speciesListA.length) {
-				speciesList.push(...speciesListA)
-			}
-			if (speciesListB.length) {
-				speciesList.push(...speciesListB)
+					}
+				})
 			}
 		}
 
-		speciesList = uniqBy(speciesList, 'ident')
+		speciesListA.forEach(speciesChecker(speciesListB))
+		remove(speciesListA, n => forRemoval.includes(n.ident))
 
-		return { species: speciesList, nm: nmInstances }
+		speciesListB.forEach(speciesChecker(speciesListA))
+		remove(speciesListB, n => forRemoval.includes(n.ident))
+
+		if (speciesListA.length) {
+			speciesList.push(...speciesListA)
+		}
+		if (speciesListB.length) {
+			speciesList.push(...speciesListB)
+		}
 	}
 
-	return { species: [node], nm: nmInstances }
+	speciesList = uniqBy(speciesList, 'ident')
+
+	return { species: speciesList, nm: nmInstances }
 }
 
 module.exports.formatData = formatData

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -193,55 +193,57 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 
 	for (let speciesName in hybridSpeciesCount) {
 		// If we've flagged every individual in this species
-		if (hybridSpeciesCount[speciesName] === totalSpeciesCount[speciesName]) {
-			// We initially assume we're going to remove everybody
-			let toRemove = []
-			let collectedHybridIdents = {}
-			for (let hybrid of results.nm) {
-				if (hybrid.name === speciesName) {
-					toRemove.push(hybrid.ident)
-				}
-			}
-			let rootNodeCopy = JSON.parse(JSON.stringify(rootNode))
-			let isMono = false
+		if (hybridSpeciesCount[speciesName] !== totalSpeciesCount[speciesName]) {
+			continue
+		}
 
-			while (!isMono) {
-				// We need to remove the one that's closest to a different species
-				// and continue to do this until monophyly is achieved
-				// Those removed ones are the true hybrids. Everyone else is unflagged
-				let shortestDist
-				let closestHybrid
-				//let newResults = recursiveSearch(rootNodeCopy)
-				for (let hybrid of results.nm) {
-					if (
-						hybrid.name === speciesName &&
-						!collectedHybridIdents[hybrid.ident]
-					) {
-						let dist = getSmallestInterSpeciesDistance(hybrid, sequenceMap)
-						if (shortestDist === undefined) {
-							shortestDist = dist
-						}
-						if (shortestDist <= dist) {
-							shortestDist = dist
-							closestHybrid = hybrid
-						}
+		// We initially assume we're going to remove everybody
+		let toRemove = []
+		let collectedHybridIdents = {}
+		for (let hybrid of results.nm) {
+			if (hybrid.name === speciesName) {
+				toRemove.push(hybrid.ident)
+			}
+		}
+		let rootNodeCopy = JSON.parse(JSON.stringify(rootNode))
+		let isMono = false
+
+		while (!isMono) {
+			// We need to remove the one that's closest to a different species
+			// and continue to do this until monophyly is achieved
+			// Those removed ones are the true hybrids. Everyone else is unflagged
+			let shortestDist
+			let closestHybrid
+			//let newResults = recursiveSearch(rootNodeCopy)
+			for (let hybrid of results.nm) {
+				if (
+					hybrid.name === speciesName &&
+					!collectedHybridIdents[hybrid.ident]
+				) {
+					let dist = getSmallestInterSpeciesDistance(hybrid, sequenceMap)
+					if (shortestDist === undefined) {
+						shortestDist = dist
+					}
+					if (shortestDist <= dist) {
+						shortestDist = dist
+						closestHybrid = hybrid
 					}
 				}
-
-				// The closest one to a different species is probably a hybrid so let's not remove it
-				if (closestHybrid === undefined) {
-					break
-				}
-				collectedHybridIdents[closestHybrid.ident] = true
-				remove(toRemove, ident => ident === closestHybrid.ident)
-				removeNodes(rootNodeCopy, [closestHybrid.ident])
-				// Now check if monophyly is achieved and repeat if not
-				isMono = isSpeciesMonophyletic(rootNodeCopy, speciesName)
 			}
 
-			// remove all the ones remaining in toRemove
-			remove(results.nm, hybrid => toRemove.includes(hybrid.ident))
+			// The closest one to a different species is probably a hybrid so let's not remove it
+			if (closestHybrid === undefined) {
+				break
+			}
+			collectedHybridIdents[closestHybrid.ident] = true
+			remove(toRemove, ident => ident === closestHybrid.ident)
+			removeNodes(rootNodeCopy, [closestHybrid.ident])
+			// Now check if monophyly is achieved and repeat if not
+			isMono = isSpeciesMonophyletic(rootNodeCopy, speciesName)
 		}
+
+		// remove all the ones remaining in toRemove
+		remove(results.nm, hybrid => toRemove.includes(hybrid.ident))
 	}
 }
 

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -157,6 +157,7 @@ function unflagIfRemovingDoesNotFix(results, rootNode) {
 			}
 		}
 	}
+
 	remove(results.nm, hybrid => unflag.includes(hybrid.ident))
 }
 
@@ -248,9 +249,8 @@ function unflagIfAllAreFlagged(results, rootNode, sequenceMap) {
 	}
 }
 
-// Given a node, it will return {species:[],nm:[]}
-// where `species` is a list of individuals under that node
-// and `nm` is a list of flagged hybrids
+// Given a node, it will return {species:[],nm:[]} where `species` is a list
+// of individuals under that node and `nm` is a list of flagged hybrids
 function recursiveSearch(node, nmInstances = []) {
 	if (!node.branchset) {
 		return { species: [node], nm: nmInstances }

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -65,12 +65,14 @@ function getMostRecentCommonAncestor(rootNode, speciesName) {
 	let rootCopy = JSON.parse(JSON.stringify(rootNode))
 	// Add parent references to each node
 	function addParent(node) {
-		if (node.branchset) {
-			for (let child of node.branchset) {
-				child.parent = node
-			}
-			node.branchset.forEach(addParent)
+		if (!node.branchset) {
+			return
 		}
+
+		for (let child of node.branchset) {
+			child.parent = node
+		}
+		node.branchset.forEach(addParent)
 	}
 
 	addParent(rootCopy)

--- a/server/ent/ent.js
+++ b/server/ent/ent.js
@@ -168,11 +168,13 @@ function getSmallestInterSpeciesDistance(individual, sequenceMap) {
 
 	for (let id of Object.keys(sequenceMap)) {
 		let speciesName = id.split(LABEL_DIVIDER)[0]
-		if (speciesName !== individual.name) {
-			let dist = hammingDistance(individualSequence, sequenceMap[id])
-			if (shortestDist === undefined || dist < shortestDist) {
-				shortestDist = dist
-			}
+		if (speciesName === individual.name) {
+			continue
+		}
+
+		let dist = hammingDistance(individualSequence, sequenceMap[id])
+		if (shortestDist === undefined || dist < shortestDist) {
+			shortestDist = dist
 		}
 	}
 


### PR DESCRIPTION
- Reduces indentation by switching loops to early-exits
- Switches a few loops to Array#filter/map instead of iteration

I highly recommend asking GitHub to hide the whitespace changes when reviewing: https://github.com/hybsearch/hybsearch/pull/228/files?w=1